### PR TITLE
Make data-analyzer callable via REST, MCP, and A2A (+ Cloud Run deploy)

### DIFF
--- a/.github/workflows/deploy-cloudrun.yml
+++ b/.github/workflows/deploy-cloudrun.yml
@@ -1,0 +1,183 @@
+# .github/workflows/deploy-cloudrun.yml
+#
+# Manual GitHub Actions workflow to build and deploy the data-analyzer API
+# to Google Cloud Run as a public (unauthenticated) endpoint.
+#
+# ============================================================
+# REQUIRED GITHUB SECRET
+# ============================================================
+# GCP_SA_KEY
+#   JSON key for a GCP Service Account with the following IAM roles:
+#     - roles/run.admin                    (deploy Cloud Run services)
+#     - roles/cloudbuild.builds.editor     (submit Cloud Build jobs)
+#     - roles/artifactregistry.admin       (create repos, push images)
+#     - roles/iam.serviceAccountUser       (impersonate the Cloud Build SA)
+#     - roles/storage.admin                (Cloud Build source staging bucket)
+#
+#   Create the key:
+#     gcloud iam service-accounts create gh-deploy-sa \
+#         --display-name="GitHub Actions deployer"
+#     gcloud projects add-iam-policy-binding PROJECT_ID \
+#         --member="serviceAccount:gh-deploy-sa@PROJECT_ID.iam.gserviceaccount.com" \
+#         --role=roles/run.admin
+#     # (repeat for each role above)
+#     gcloud iam service-accounts keys create sa-key.json \
+#         --iam-account=gh-deploy-sa@PROJECT_ID.iam.gserviceaccount.com
+#   Then add the contents of sa-key.json as the GCP_SA_KEY repository secret.
+#
+# SECURITY NOTE — Workload Identity Federation is the more secure alternative:
+#   WIF eliminates long-lived service account keys by federating GitHub's OIDC
+#   token directly. See:
+#   https://github.com/google-github-actions/auth#setting-up-workload-identity-federation
+#   Use google-github-actions/auth@v2 with workload_identity_provider + service_account
+#   instead of credentials_json to adopt WIF.
+#
+# ============================================================
+# ALLOW-UNAUTHENTICATED WARNING
+# ============================================================
+# This workflow deploys with --allow-unauthenticated, making the Cloud Run
+# service reachable by anyone on the public internet. This is fine for a
+# temporary demo. Before processing real or sensitive data, add authentication:
+#   - Cloud Run IAM (remove allUsers binding, add invoker role per identity)
+#   - Google Cloud Endpoints / API Gateway with an API key or JWT
+# ============================================================
+
+name: Deploy to Cloud Run
+
+on:
+  workflow_dispatch:
+    inputs:
+      project_id:
+        description: 'GCP Project ID'
+        required: true
+        type: string
+      region:
+        description: 'GCP region'
+        required: false
+        default: 'us-central1'
+        type: string
+      service:
+        description: 'Cloud Run service name'
+        required: false
+        default: 'data-analyzer-api'
+        type: string
+
+jobs:
+  deploy:
+    name: Build and Deploy
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write   # needed if/when switching to Workload Identity Federation
+
+    steps:
+      # ------------------------------------------------------------------
+      # 1. Checkout source
+      # ------------------------------------------------------------------
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # ------------------------------------------------------------------
+      # 2. Authenticate to GCP using the service account JSON key.
+      #    To switch to Workload Identity Federation, replace credentials_json
+      #    with workload_identity_provider and service_account inputs.
+      # ------------------------------------------------------------------
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      # ------------------------------------------------------------------
+      # 3. Set up gcloud CLI
+      # ------------------------------------------------------------------
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          project_id: ${{ inputs.project_id }}
+
+      # ------------------------------------------------------------------
+      # 4. Derive image path and configure Docker for Artifact Registry
+      # ------------------------------------------------------------------
+      - name: Configure Docker for Artifact Registry
+        run: |
+          gcloud auth configure-docker "${{ inputs.region }}-docker.pkg.dev" --quiet
+
+      # ------------------------------------------------------------------
+      # 5. Ensure Artifact Registry repository 'apps' exists (idempotent)
+      # ------------------------------------------------------------------
+      - name: Ensure Artifact Registry repository
+        run: |
+          gcloud artifacts repositories create apps \
+            --repository-format=docker \
+            --location="${{ inputs.region }}" \
+            --project="${{ inputs.project_id }}" \
+            --description="Container images for deployed services" \
+            2>&1 || true
+
+      # ------------------------------------------------------------------
+      # 6. Build and push image via Cloud Build
+      # ------------------------------------------------------------------
+      - name: Build and push image
+        env:
+          IMAGE: "${{ inputs.region }}-docker.pkg.dev/${{ inputs.project_id }}/apps/${{ inputs.service }}:${{ github.sha }}"
+        run: |
+          gcloud builds submit \
+            --config=cloudbuild.yaml \
+            --substitutions="_IMAGE=${IMAGE}" \
+            --project="${{ inputs.project_id }}" \
+            .
+
+      # ------------------------------------------------------------------
+      # 7. Deploy to Cloud Run (public, unauthenticated)
+      # ------------------------------------------------------------------
+      - name: Deploy to Cloud Run
+        env:
+          IMAGE: "${{ inputs.region }}-docker.pkg.dev/${{ inputs.project_id }}/apps/${{ inputs.service }}:${{ github.sha }}"
+        run: |
+          gcloud run deploy "${{ inputs.service }}" \
+            --image="${IMAGE}" \
+            --region="${{ inputs.region }}" \
+            --platform=managed \
+            --allow-unauthenticated \
+            --port=8080 \
+            --project="${{ inputs.project_id }}"
+
+      # ------------------------------------------------------------------
+      # 8. Retrieve and print the public service URL
+      # ------------------------------------------------------------------
+      - name: Get service URL
+        id: get-url
+        run: |
+          SERVICE_URL=$(gcloud run services describe "${{ inputs.service }}" \
+            --region="${{ inputs.region }}" \
+            --project="${{ inputs.project_id }}" \
+            --format='value(status.url)')
+          echo "service_url=${SERVICE_URL}" >> "$GITHUB_OUTPUT"
+          echo "Service deployed at: ${SERVICE_URL}"
+
+      # ------------------------------------------------------------------
+      # 9. Write URL to job summary
+      # ------------------------------------------------------------------
+      - name: Write summary
+        run: |
+          {
+            echo "## Cloud Run Deployment"
+            echo ""
+            echo "| Field | Value |"
+            echo "|-------|-------|"
+            echo "| Service | \`${{ inputs.service }}\` |"
+            echo "| Region | \`${{ inputs.region }}\` |"
+            echo "| Project | \`${{ inputs.project_id }}\` |"
+            echo "| Commit | \`${{ github.sha }}\` |"
+            echo "| **Public URL** | ${{ steps.get-url.outputs.service_url }} |"
+            echo ""
+            echo "### Quick smoke test"
+            echo "\`\`\`bash"
+            echo "curl ${{ steps.get-url.outputs.service_url }}/health"
+            echo "\`\`\`"
+            echo ""
+            echo "### End-to-end A2A check"
+            echo "\`\`\`bash"
+            echo "python3 scripts/e2e_a2a_check.py --url ${{ steps.get-url.outputs.service_url }}"
+            echo "\`\`\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,26 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Resuming work — read this first
+
+State travels with the git branch — there are no local-only handoff files. Reconstruct
+context from git before doing anything else.
+
+**RESUMING:** To continue prior work:
+1. If an open PR exists for the branch, its description is the live handoff — read it first.
+2. If no PR, read `git log --oneline -20` and the latest commit body
+   (`git show -s --format=%B HEAD`); a handoff commit ends with a `Handoff:` section
+   listing next steps.
+
+Then continue.
+
+**HANDING OFF:** When you pause or finish a chunk, leave a clean handoff that travels
+with the branch:
+- At a PR-worthy point, open or update a PR whose description lists what's done, what's
+  pending, required env vars, and the exact commands to run.
+- Mid-work (no PR yet), commit your progress with a `Handoff:` section at the end of the
+  commit message (done / next steps / caveats) and push.
+
 ## CRITICAL: Agent Delegation Philosophy
 
 **YOU MUST PROACTIVELY DELEGATE TO AGENTS TO CONSERVE CONTEXT.**

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -1,0 +1,43 @@
+# Dockerfile.api — API-only image for Cloud Run (no Streamlit, no LLM deps).
+#
+# Build:
+#   docker build -f Dockerfile.api -t data-analyzer-api .
+#
+# Run locally:
+#   docker run -p 8080:8080 data-analyzer-api
+#
+# Cloud Run injects $PORT at runtime; the CMD shell form expands it correctly.
+
+FROM python:3.11-slim
+
+# Install curl for the HEALTHCHECK and ca-certificates for TLS; then clean up.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Copy and install runtime dependencies first (layer-caching friendly).
+COPY requirements-api.txt .
+RUN pip install --no-cache-dir -r requirements-api.txt
+
+# Copy all application source.
+# analysis_service.py, a2a_agent.py, a2a_runtime/ are all required at runtime.
+COPY . .
+
+# Run as a non-root user for defence-in-depth.
+RUN useradd --no-create-home --shell /bin/false appuser \
+    && chown -R appuser:appuser /app
+USER appuser
+
+# Cloud Run sets $PORT (default 8080 per platform convention).
+ENV PORT=8080
+EXPOSE 8080
+
+# HEALTHCHECK — Cloud Run also has its own liveness probe, but this is useful
+# for local docker run and for surfacing failures early in the build pipeline.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD curl --fail http://localhost:${PORT:-8080}/health || exit 1
+
+# Shell form so ${PORT:-8080} is expanded by /bin/sh at container startup.
+CMD ["sh", "-c", "exec uvicorn api_server:app --host 0.0.0.0 --port ${PORT:-8080}"]

--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 A comprehensive data quality analysis tool built with Azure MCP (Model Context Protocol) server and Streamlit web interface. Supports multiple data formats including CSV, JSON, Excel (XLSX/XLS), and Parquet with comprehensive data quality analysis capabilities. Based on your [csvChecker](https://github.com/sagearbor/csvChecker) repository with enhanced cloud capabilities.
 
+## Calling this service (REST / MCP / A2A)
+
+This service exposes the same analysis core through three interfaces:
+
+- **REST API** — `python api_server.py` (default port 8003); endpoints `/analyze`, `/data-info`, `/health`
+- **MCP** — `python mcp_server.py` (stdio); tools `analyze_data` and `get_data_info` for Claude Desktop / Cursor
+- **A2A** — `POST /a2a/data-analyzer` with an encoded A2A Message envelope; AgentCard at `GET /.well-known/agent.json`
+
+See **[docs/INTEGRATION.md](docs/INTEGRATION.md)** for full curl examples, payload schemas, and A2A envelope details.
+
 ## 🏗️ Architecture
 
 ```

--- a/a2a_agent.py
+++ b/a2a_agent.py
@@ -1,0 +1,151 @@
+"""
+a2a_agent.py — A2A-protocol agent wrapper for the data-analyzer service.
+
+This module is importable under plain python3 with zero heavy dependencies.
+All heavy work (analysis_service, pandas) is imported lazily inside ``run()``.
+
+Usage
+-----
+    from a2a_agent import DataAnalyzerAgent, build_card, register
+
+    # Register into the default in-process registry (idempotent)
+    register()
+
+    # Build the AgentCard for /.well-known/agent.json
+    card = build_card(internal_only=False)
+
+    # Use the agent directly (async)
+    agent = DataAnalyzerAgent()
+    result = await agent.run({"operation": "analyze", "data_content": "..."})
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from a2a_runtime import (
+    AgentRegistry,
+    build_agent_card,
+    default_registry,
+)
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+_AGENT_ID = "data-analyzer"
+_AGENT_NAME = "Data Analyzer"
+_AGENT_DESCRIPTION = (
+    "Runs data-quality checks (type validation, range checks, missing-value "
+    "analysis, duplicate detection) on CSV/JSON/Excel/Parquet data. "
+    "Accepts base64 or plain-text data_content. "
+    "Dispatch via operation='analyze' (full pipeline) or operation='get_info' "
+    "(lightweight shape/column/sample info)."
+)
+_AGENT_VERSION = "1.0.0"
+
+
+# ---------------------------------------------------------------------------
+# Agent class
+# ---------------------------------------------------------------------------
+
+class DataAnalyzerAgent:
+    """A2A-protocol runnable agent that delegates to analysis_service.
+
+    Implements the ``RunnableAgent`` structural protocol required by
+    ``AgentRegistry``: exposes ``agent_id`` (str attribute) and
+    ``run(payload)`` (async method returning dict).
+    """
+
+    agent_id: str = _AGENT_ID
+
+    async def run(self, payload: dict) -> dict:  # noqa: D102
+        """Dispatch the payload to the appropriate analysis_service function.
+
+        Parameters
+        ----------
+        payload:
+            A plain dict decoded from the A2A envelope. Expected keys:
+            - operation (str, optional): "analyze" (default) | "get_info" | "data_info"
+            - data_content, file_format, schema, rules, min_rows, encoding,
+              sample_rows — forwarded verbatim to analysis_service.
+
+        Returns
+        -------
+        dict
+            JSON-serialisable result from analysis_service, or an error dict.
+        """
+        # Lazy import so this module loads with stdlib only.
+        import analysis_service  # noqa: PLC0415
+
+        operation: str = payload.get("operation", "analyze").lower()
+
+        logger.debug("DataAnalyzerAgent.run: operation=%r", operation)
+
+        if operation == "analyze":
+            return analysis_service.analyze(payload)
+
+        if operation in ("get_info", "data_info"):
+            return analysis_service.get_info(payload)
+
+        # Unknown operation — return a consistent error dict (never raise).
+        logger.warning("DataAnalyzerAgent: unknown operation %r", operation)
+        return {
+            "error": (
+                f"Unknown operation {operation!r}. "
+                "Supported values: 'analyze', 'get_info'."
+            ),
+            "type": "unknown_operation",
+        }
+
+
+# ---------------------------------------------------------------------------
+# AgentCard helper
+# ---------------------------------------------------------------------------
+
+def build_card(internal_only: bool = False) -> dict:
+    """Build the AgentCard dict for /.well-known/agent.json.
+
+    Parameters
+    ----------
+    internal_only:
+        Pass ``False`` when serving publicly (e.g. from ``api_server.py``).
+        The default is ``False`` to match the typical external-facing use-case;
+        callers that want the card to be marked internal-only must opt-in.
+
+    Returns
+    -------
+    dict
+        AgentCard dict ready to serialise via ``serve_agent_card()``.
+    """
+    return build_agent_card(
+        _AGENT_ID,
+        _AGENT_NAME,
+        _AGENT_DESCRIPTION,
+        version=_AGENT_VERSION,
+        internal_only=internal_only,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Registry helper
+# ---------------------------------------------------------------------------
+
+def register(registry: Optional[AgentRegistry] = None) -> None:
+    """Register a ``DataAnalyzerAgent`` into a registry (idempotent).
+
+    If ``registry`` is ``None``, registers into ``a2a_runtime.default_registry``.
+    Calling this function multiple times is safe — it always overwrites the
+    previous entry with a fresh ``DataAnalyzerAgent`` instance.
+
+    Parameters
+    ----------
+    registry:
+        Target ``AgentRegistry``. Defaults to ``default_registry``.
+    """
+    target: AgentRegistry = registry if registry is not None else default_registry
+    agent = DataAnalyzerAgent()
+    target.register(agent)
+    logger.info("Registered DataAnalyzerAgent (id=%r) into registry %r", _AGENT_ID, target)

--- a/a2a_runtime/__init__.py
+++ b/a2a_runtime/__init__.py
@@ -1,0 +1,83 @@
+"""A2A runtime: prefer the real ``dcri-a2a-core``, fall back to a local shim.
+
+Every adapter in this repo (REST / MCP / A2A) imports its A2A primitives from
+``a2a_runtime`` rather than importing ``dcri_a2a_core`` directly. That single
+indirection means:
+
+  * When ``dcri-a2a-core`` is installed (the org's published foundation
+    package), the real, versioned wire contract is used — no code change.
+  * When it is not yet installed (offline sandbox, fresh clone), the pure-stdlib
+    ``_shim`` provides the identical public names so the service still runs.
+
+Check ``A2A_BACKEND`` / ``IS_A2A_SHIM`` at runtime to see which is active; the
+``/health`` and AgentCard surfaces report it so operators know whether they are
+on the real wire contract.
+
+To go to the real contract: ``pip install dcri-a2a-core`` (and optionally delete
+``a2a_runtime/_shim.py``); nothing else changes because the names match.
+"""
+
+from __future__ import annotations
+
+try:  # Prefer the real, versioned foundation package.
+    from dcri_a2a_core import (  # type: ignore
+        A2A_IMPLEMENTED_METHODS,
+        A2A_MINIMAL_CAPABILITIES,
+        AGENT_PATH_TEMPLATE,
+        PAYLOAD_MEDIA_TYPE,
+        WELL_KNOWN_PATH,
+        A2AClient,
+        AgentRegistry,
+        RunnableAgent,
+        build_agent_card,
+        correlation_id_of,
+        cycle_of,
+        decode_message,
+        default_registry,
+        encode_message,
+        serve_agent_card,
+    )
+
+    IS_A2A_SHIM = False
+    A2A_BACKEND = "dcri-a2a-core"
+except ImportError:  # Fall back to the bundled stdlib shim.
+    from ._shim import (  # type: ignore
+        A2A_IMPLEMENTED_METHODS,
+        A2A_MINIMAL_CAPABILITIES,
+        AGENT_PATH_TEMPLATE,
+        PAYLOAD_MEDIA_TYPE,
+        WELL_KNOWN_PATH,
+        A2AClient,
+        AgentRegistry,
+        RunnableAgent,
+        build_agent_card,
+        correlation_id_of,
+        cycle_of,
+        decode_message,
+        default_registry,
+        encode_message,
+        serve_agent_card,
+    )
+
+    IS_A2A_SHIM = True
+    A2A_BACKEND = "shim"
+
+__all__ = [
+    "IS_A2A_SHIM",
+    "A2A_BACKEND",
+    "A2A_IMPLEMENTED_METHODS",
+    "A2A_MINIMAL_CAPABILITIES",
+    "AGENT_PATH_TEMPLATE",
+    "PAYLOAD_MEDIA_TYPE",
+    "WELL_KNOWN_PATH",
+    "A2AClient",
+    "AgentRegistry",
+    "RunnableAgent",
+    "build_agent_card",
+    "correlation_id_of",
+    "cycle_of",
+    "decode_message",
+    "default_registry",
+    "encode_message",
+    "serve_agent_card",
+]

--- a/a2a_runtime/_shim.py
+++ b/a2a_runtime/_shim.py
@@ -1,0 +1,251 @@
+"""Pure-stdlib fallback that mirrors the ``dcri-a2a-core`` public API.
+
+This module is a **temporary stand-in** for the sibling foundation package
+``dcri-a2a-core`` (https://github.com/sagearbor/dcri-a2a-core). That package is
+the canonical A2A wire contract every DCRI agent imports, but it depends on
+``a2a-sdk`` + ``pydantic`` and is distributed as a path/index dependency that
+may not be installed yet (e.g. in an offline sandbox).
+
+``a2a_runtime/__init__.py`` prefers the real package and falls back to this
+shim, so this repo's REST / MCP / A2A adapters import the *same names* either
+way. The names and call signatures here intentionally match the real package's
+``__all__`` so swapping in the real one is a no-op:
+
+    encode_message / decode_message / correlation_id_of / cycle_of
+    AgentRegistry / A2AClient / default_registry / RunnableAgent
+    build_agent_card / serve_agent_card
+    AGENT_PATH_TEMPLATE / WELL_KNOWN_PATH
+    A2A_MINIMAL_CAPABILITIES / A2A_IMPLEMENTED_METHODS / PAYLOAD_MEDIA_TYPE
+
+Differences from the real package (all invisible to callers):
+  * A "Message" here is a plain ``dict`` envelope, not an a2a-sdk protobuf type.
+    There is therefore no protobuf float/Struct coercion to funnel — ``cycle``
+    is still re-coerced to ``int`` in ``decode_message`` so the contract holds.
+  * No real network transport: a remote target with no ``remote_sender`` raises
+    the same ``LookupError`` the real package raises until its HTTP client lands.
+
+DELETE this file once ``dcri-a2a-core`` is installable; nothing else changes.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Awaitable, Callable, Optional, Protocol, Tuple, runtime_checkable
+
+# Marker so callers/tests can detect whether the shim or the real package is live.
+IS_A2A_SHIM = True
+
+# ---------------------------------------------------------------------------
+# Constants (must match dcri_a2a_core.envelope)
+# ---------------------------------------------------------------------------
+A2A_MINIMAL_CAPABILITIES = {"streaming": False, "pushNotifications": False}
+A2A_IMPLEMENTED_METHODS = ("message/send", "tasks/get")
+PAYLOAD_MEDIA_TYPE = "application/json"
+
+AGENT_PATH_TEMPLATE = "/a2a/{agent_id}"
+WELL_KNOWN_PATH = "/.well-known/agent.json"
+
+# A "payload" is a JSON dict or any object exposing ``.model_dump()`` (pydantic).
+Payload = Any
+Message = dict
+
+
+# ---------------------------------------------------------------------------
+# Envelope seam
+# ---------------------------------------------------------------------------
+def _as_dict(payload: Payload) -> dict:
+    """Coerce a payload (dict or pydantic-like model) to a plain JSON dict."""
+    if payload is None:
+        return {}
+    if isinstance(payload, dict):
+        return payload
+    model_dump = getattr(payload, "model_dump", None)
+    if callable(model_dump):
+        return model_dump()
+    raise TypeError(
+        f"A2A payload must be a dict or expose .model_dump(); got {type(payload)!r}"
+    )
+
+
+def encode_message(
+    payload: Payload,
+    *,
+    correlation_id: str,
+    cycle: int = 1,
+    agent_id: Optional[str] = None,
+) -> Message:
+    """Wrap ``payload`` in the canonical A2A envelope.
+
+    The payload rides as a JSON data part; ``correlation_id`` / ``cycle`` /
+    ``agent_id`` ride in the message metadata. JSON round-trip here mirrors the
+    serialization the real wire performs.
+    """
+    data_part = json.loads(json.dumps(_as_dict(payload)))
+    return {
+        "payload": data_part,
+        "metadata": {
+            "correlation_id": correlation_id,
+            "cycle": int(cycle),
+            "agent_id": agent_id,
+        },
+    }
+
+
+def decode_message(message: Message) -> Tuple[dict, dict]:
+    """Return ``(payload_dict, metadata_dict)`` from an envelope.
+
+    ``cycle`` is re-coerced to ``int`` so callers see a stable contract
+    regardless of how the transport stored it (matches the real package, which
+    undoes protobuf's float coercion here).
+    """
+    payload = dict(message.get("payload", {}))
+    meta_in = dict(message.get("metadata", {}))
+    metadata = {
+        "correlation_id": meta_in.get("correlation_id"),
+        "cycle": int(meta_in.get("cycle", 1)),
+        "agent_id": meta_in.get("agent_id"),
+    }
+    return payload, metadata
+
+
+def correlation_id_of(message: Message) -> Optional[str]:
+    """Metadata accessor for the correlation id."""
+    return message.get("metadata", {}).get("correlation_id")
+
+
+def cycle_of(message: Message) -> int:
+    """Metadata accessor for the cycle (coerced to ``int``)."""
+    return int(message.get("metadata", {}).get("cycle", 1))
+
+
+# ---------------------------------------------------------------------------
+# Registry + uniform caller
+# ---------------------------------------------------------------------------
+@runtime_checkable
+class RunnableAgent(Protocol):
+    """Structural type the registry can dispatch to: ``agent_id`` + ``run``."""
+
+    agent_id: str
+
+    async def run(self, payload: dict) -> dict: ...
+
+
+class AgentRegistry:
+    """In-process directory of locally-registered agents (id -> agent)."""
+
+    def __init__(self) -> None:
+        self._agents: dict[str, RunnableAgent] = {}
+
+    def register(self, agent: RunnableAgent) -> None:
+        self._agents[agent.agent_id] = agent
+
+    def get(self, agent_id: str) -> Optional[RunnableAgent]:
+        return self._agents.get(agent_id)
+
+    def clear(self) -> None:
+        self._agents.clear()
+
+
+default_registry = AgentRegistry()
+
+RemoteSender = Callable[[str, Any], Awaitable[Any]]
+
+
+class A2AClient:
+    """Uniform inter-agent caller: in-process short-circuit, else remote seam."""
+
+    def __init__(
+        self,
+        registry: Optional[AgentRegistry] = None,
+        *,
+        remote_sender: Optional[RemoteSender] = None,
+        bearer_token: Optional[str] = None,
+    ) -> None:
+        self._registry = registry if registry is not None else default_registry
+        self._remote_sender = remote_sender
+        self._bearer_token = bearer_token
+
+    async def call(
+        self,
+        agent_id: str,
+        payload: Payload,
+        *,
+        correlation_id: str,
+        cycle: int = 1,
+    ) -> dict:
+        # Encode even locally so the wire-shape is exercised identically.
+        request = encode_message(
+            payload, correlation_id=correlation_id, cycle=cycle, agent_id=agent_id
+        )
+        local = self._registry.get(agent_id)
+        if local is not None:
+            request_payload, _ = decode_message(request)
+            return await local.run(request_payload)
+        return await self._call_remote(agent_id, request)
+
+    async def _call_remote(self, agent_id: str, request: Any) -> dict:
+        if self._remote_sender is None:
+            raise LookupError(
+                f"Agent {agent_id!r} is not registered locally and no remote "
+                "sender is configured. Register the agent for the in-process "
+                "short-circuit, or install dcri-a2a-core for the real HTTP hop."
+            )
+        response = await self._remote_sender(agent_id, request)
+        payload, _ = decode_message(response)
+        return payload
+
+
+# ---------------------------------------------------------------------------
+# AgentCard helpers
+# ---------------------------------------------------------------------------
+def build_agent_card(
+    agent_id: str,
+    name: str,
+    description: str,
+    *,
+    version: str,
+    payload_schema_url: Optional[str] = None,
+    internal_only: bool = True,
+) -> dict:
+    """Build the ``/.well-known/agent.json`` AgentCard dict (transport-only)."""
+    card: dict[str, Any] = {
+        "name": name,
+        "description": description,
+        "version": version,
+        "url": AGENT_PATH_TEMPLATE.format(agent_id=agent_id),
+        "capabilities": dict(A2A_MINIMAL_CAPABILITIES),
+        "methods": list(A2A_IMPLEMENTED_METHODS),
+        "defaultInputModes": [PAYLOAD_MEDIA_TYPE],
+        "defaultOutputModes": [PAYLOAD_MEDIA_TYPE],
+        "x-dcri": {"agent_id": agent_id, "internal_only": internal_only},
+    }
+    if payload_schema_url is not None:
+        card["x-dcri"]["payload_schema_url"] = payload_schema_url
+    return card
+
+
+def serve_agent_card(card: dict) -> Tuple[str, dict, str]:
+    """Render an AgentCard for serving at :data:`WELL_KNOWN_PATH`."""
+    body = json.dumps(card, indent=2, sort_keys=True)
+    headers = {"Cache-Control": "public, max-age=300"}
+    return body, headers, "application/json"
+
+
+__all__ = [
+    "IS_A2A_SHIM",
+    "A2A_MINIMAL_CAPABILITIES",
+    "A2A_IMPLEMENTED_METHODS",
+    "PAYLOAD_MEDIA_TYPE",
+    "encode_message",
+    "decode_message",
+    "correlation_id_of",
+    "cycle_of",
+    "AgentRegistry",
+    "A2AClient",
+    "default_registry",
+    "RunnableAgent",
+    "build_agent_card",
+    "serve_agent_card",
+    "AGENT_PATH_TEMPLATE",
+    "WELL_KNOWN_PATH",
+]

--- a/a2a_runtime/http_client.py
+++ b/a2a_runtime/http_client.py
@@ -1,0 +1,157 @@
+"""Real over-the-network A2A client — the hop ``dcri-a2a-core`` leaves as a stub.
+
+``dcri_a2a_core.A2AClient._call_remote`` is a documented TODO: the foundation
+package can receive A2A calls but cannot yet *make* one over HTTP. This module
+implements that missing hop so a caller (e.g. a ``dcri-ct-graph`` node, or any
+org service) can actually reach a deployed agent.
+
+It speaks the **canonical DCRI JSON envelope** — the same shape this repo's
+``/a2a/{agent_id}`` endpoint accepts — by POSTing the encoded message to
+``{base_url}/a2a/{agent_id}`` and decoding the reply. It is **stdlib-only**
+(``urllib``) on purpose: no ``requests``/``httpx`` dependency, importable in any
+environment, and trivial to run from a CI smoke test.
+
+Usage — direct call::
+
+    from a2a_runtime.http_client import call_agent_http
+    result = call_agent_http(
+        "https://data-analyzer-xxxx.run.app", "data-analyzer",
+        {"operation": "analyze", "data_content": "<base64-csv>"},
+        correlation_id="c1",
+    )
+
+Usage — as the remote_sender for the uniform ``A2AClient`` (so local and remote
+callers use the identical ``client.call(...)`` path)::
+
+    from a2a_runtime import A2AClient
+    from a2a_runtime.http_client import make_http_remote_sender
+    sender = make_http_remote_sender({"data-analyzer": "https://...run.app"})
+    client = A2AClient(remote_sender=sender)
+    result = await client.call("data-analyzer", payload, correlation_id="c1")
+
+NOTE on the real package: when ``dcri-a2a-core`` (a2a-sdk based) is installed,
+``encode_message`` returns a protobuf ``Message`` rather than a dict. This module
+serializes either form to the canonical JSON envelope via ``model_dump()``. The
+remaining parity point to verify against the real package is whether its inbound
+route expects the a2a-sdk JSON-RPC ``message/send`` framing; see docs/INTEGRATION.md.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import urllib.error
+import urllib.request
+from typing import Any, Callable, Mapping, Optional, Union
+
+from . import decode_message, encode_message
+
+__all__ = ["call_agent_http", "make_http_remote_sender", "A2AHttpError"]
+
+
+class A2AHttpError(RuntimeError):
+    """Raised when the remote A2A call fails at the transport level."""
+
+
+def _to_json_envelope(message: Any) -> dict:
+    """Coerce an encoded message (shim dict OR a2a-sdk Message) to a JSON dict."""
+    if isinstance(message, dict):
+        return message
+    model_dump = getattr(message, "model_dump", None)
+    if callable(model_dump):
+        return model_dump()
+    raise TypeError(
+        f"Cannot serialize encoded A2A message of type {type(message)!r} to JSON."
+    )
+
+
+def _endpoint(base_url: str, agent_id: str) -> str:
+    return base_url.rstrip("/") + "/a2a/" + agent_id
+
+
+def _post_envelope(
+    url: str, envelope: dict, *, bearer_token: Optional[str], timeout: float
+) -> dict:
+    """POST a JSON envelope and return the decoded JSON response body."""
+    body = json.dumps(envelope).encode("utf-8")
+    headers = {"Content-Type": "application/json", "Accept": "application/json"}
+    if bearer_token:
+        headers["Authorization"] = f"Bearer {bearer_token}"
+    req = urllib.request.Request(url, data=body, method="POST", headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            raw = resp.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:  # 4xx/5xx
+        detail = exc.read().decode("utf-8", "replace") if exc.fp else ""
+        raise A2AHttpError(f"A2A call to {url} failed: HTTP {exc.code} {detail}") from exc
+    except urllib.error.URLError as exc:  # DNS / connection
+        raise A2AHttpError(f"A2A call to {url} failed: {exc.reason}") from exc
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise A2AHttpError(f"A2A reply from {url} was not JSON: {raw[:200]!r}") from exc
+
+
+def call_agent_http(
+    base_url: str,
+    agent_id: str,
+    payload: dict,
+    *,
+    correlation_id: str,
+    cycle: int = 1,
+    bearer_token: Optional[str] = None,
+    timeout: float = 60.0,
+) -> dict:
+    """Call a deployed agent over HTTP and return its response payload dict.
+
+    Encodes ``payload`` into the canonical envelope, POSTs it to
+    ``{base_url}/a2a/{agent_id}``, then decodes and returns the reply payload.
+    Raises :class:`A2AHttpError` on any transport-level failure.
+    """
+    request_msg = encode_message(
+        payload, correlation_id=correlation_id, cycle=cycle, agent_id=agent_id
+    )
+    response_envelope = _post_envelope(
+        _endpoint(base_url, agent_id),
+        _to_json_envelope(request_msg),
+        bearer_token=bearer_token,
+        timeout=timeout,
+    )
+    result_payload, _meta = decode_message(response_envelope)
+    return result_payload
+
+
+def make_http_remote_sender(
+    resolve_base_url: Union[Mapping[str, str], Callable[[str], str]],
+    *,
+    bearer_token: Optional[str] = None,
+    timeout: float = 60.0,
+):
+    """Build an async ``remote_sender`` for :class:`a2a_runtime.A2AClient`.
+
+    ``resolve_base_url`` maps an ``agent_id`` to its base URL — either a plain
+    ``{agent_id: base_url}`` dict or a callable ``agent_id -> base_url``. The
+    returned coroutine matches the ``A2AClient`` remote-seam contract:
+    ``async (agent_id, encoded_request) -> encoded_response``.
+    """
+    if callable(resolve_base_url):
+        resolver = resolve_base_url
+    else:
+        mapping = dict(resolve_base_url)
+
+        def resolver(agent_id: str) -> str:
+            try:
+                return mapping[agent_id]
+            except KeyError as exc:
+                raise A2AHttpError(
+                    f"No base URL configured for agent {agent_id!r}."
+                ) from exc
+
+    async def _sender(agent_id: str, request_message: Any) -> dict:
+        url = _endpoint(resolver(agent_id), agent_id)
+        envelope = _to_json_envelope(request_message)
+        return await asyncio.to_thread(
+            _post_envelope, url, envelope, bearer_token=bearer_token, timeout=timeout
+        )
+
+    return _sender

--- a/analysis_service.py
+++ b/analysis_service.py
@@ -1,0 +1,174 @@
+"""
+analysis_service.py — Shared core for all three transport layers (REST, MCP, A2A).
+
+Both REST endpoints and the A2A agent delegate here. MCP tool handlers also delegate
+here (after their refactor) so all three surfaces stay in sync.
+
+IMPORTANT: This module has NO module-level heavy imports (no pandas, no mcp, no fastapi).
+All heavy classes are imported lazily inside function bodies to keep this importable
+under plain python3 without any installed packages.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _decode_data_content(data_content: str, encoding: str = "utf-8") -> str:
+    """Decode base64 or data-URL encoded content to a plain string.
+
+    Mirrors the exact decode/normalisation logic from the MCP tool handlers so
+    all three transport layers behave identically.
+    """
+    try:
+        if data_content.startswith("data:"):
+            # Handle data URLs: "data:<mime>;base64,<data>"
+            _header, data = data_content.split(",", 1)
+            return base64.b64decode(data).decode(encoding)
+
+        # Heuristic: if length is a multiple of 4 and the character set looks
+        # like base64, try decoding. Accept only if the result contains a CSV
+        # or TSV delimiter (avoids false-positives on short plain-text strings).
+        if len(data_content) % 4 == 0 and all(
+            c in "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/="
+            for c in data_content
+        ):
+            try:
+                decoded = base64.b64decode(data_content).decode(encoding)
+                if "," in decoded or "\t" in decoded:
+                    return decoded
+            except Exception:
+                pass  # Not valid base64; fall through
+
+    except Exception:
+        pass  # Any unexpected error: return content as-is
+
+    return data_content
+
+
+def _safe_import_core():
+    """Lazily import the core analysis classes from mcp_server.
+
+    Returns (DataLoader, QualityPipeline, DataDictionaryParser).
+    Raises ImportError with a helpful message if mcp_server cannot be loaded.
+    """
+    try:
+        from mcp_server import DataLoader, QualityPipeline, DataDictionaryParser  # noqa: PLC0415
+        return DataLoader, QualityPipeline, DataDictionaryParser
+    except ImportError as exc:
+        raise ImportError(
+            "Cannot import core analysis classes from mcp_server.py. "
+            "Ensure pandas/numpy are installed and mcp_server.py is on the path."
+        ) from exc
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def analyze(payload: dict) -> dict:
+    """Run a full data-quality analysis and return the results dict.
+
+    Parameters
+    ----------
+    payload:
+        JSON-serialisable dict with keys:
+        - data_content (str, required): raw CSV/JSON/… text, base64, or data-URL
+        - file_format (str, optional, default "csv")
+        - schema (dict, optional): column-type mapping
+        - rules (dict, optional): validation-rule mapping
+        - min_rows (int, optional, default 1)
+        - encoding (str, optional, default "utf-8")
+
+    Returns
+    -------
+    dict
+        The quality pipeline result dict, or ``{"error": "...", "type": "..."}``
+        on bad input so every transport layer sees a consistent error shape.
+    """
+    try:
+        DataLoader, QualityPipeline, _DDP = _safe_import_core()
+
+        data_content: str = payload.get("data_content", "")
+        if not data_content:
+            return {"error": "data_content is required", "type": "validation_error"}
+
+        file_format: str = payload.get("file_format", "csv")
+        schema: dict = payload.get("schema") or {}
+        rules: dict = payload.get("rules") or {}
+        min_rows: int = int(payload.get("min_rows", 1))
+        encoding: str = payload.get("encoding", "utf-8")
+
+        # Decode / normalise content
+        data_content = _decode_data_content(data_content, encoding)
+
+        logger.debug("analyze: format=%s rows_min=%d", file_format, min_rows)
+
+        df = DataLoader.load_data(data_content, file_format)
+        pipeline = QualityPipeline(df, schema, rules)
+        results: dict = pipeline.run_all_checks(min_rows)
+
+        return results
+
+    except Exception as exc:  # noqa: BLE001
+        logger.error("analyze error: %s", exc, exc_info=True)
+        return {"error": str(exc), "type": "analysis_error"}
+
+
+def get_info(payload: dict) -> dict:
+    """Return lightweight info about a dataset (shape, columns, sample rows, …).
+
+    Parameters
+    ----------
+    payload:
+        JSON-serialisable dict with keys:
+        - data_content (str, required)
+        - file_format (str, optional, default "csv")
+        - sample_rows (int, optional, default 5)
+        - encoding (str, optional, default "utf-8")
+
+    Returns
+    -------
+    dict
+        Info dict, or ``{"error": "...", "type": "..."}`` on failure.
+    """
+    try:
+        DataLoader, _QP, _DDP = _safe_import_core()
+
+        data_content: str = payload.get("data_content", "")
+        if not data_content:
+            return {"error": "data_content is required", "type": "validation_error"}
+
+        file_format: str = payload.get("file_format", "csv")
+        sample_rows: int = int(payload.get("sample_rows", 5))
+        encoding: str = payload.get("encoding", "utf-8")
+
+        data_content = _decode_data_content(data_content, encoding)
+
+        logger.debug("get_info: format=%s sample_rows=%d", file_format, sample_rows)
+
+        df = DataLoader.load_data(data_content, file_format)
+
+        info: dict[str, Any] = {
+            "format": file_format,
+            "shape": {"rows": len(df), "columns": len(df.columns)},
+            "columns": list(df.columns),
+            "dtypes": {col: str(dtype) for col, dtype in df.dtypes.items()},
+            "sample_data": df.head(sample_rows).to_dict(orient="records"),
+            "missing_values": df.isnull().sum().to_dict(),
+            "duplicate_rows": int(df.duplicated().sum()),
+        }
+
+        return info
+
+    except Exception as exc:  # noqa: BLE001
+        logger.error("get_info error: %s", exc, exc_info=True)
+        return {"error": str(exc), "type": "info_error"}

--- a/api_server.py
+++ b/api_server.py
@@ -1,0 +1,230 @@
+"""
+api_server.py — FastAPI REST + A2A gateway for the data-analyzer service.
+
+Endpoints
+---------
+GET  /health                  Liveness probe; reports A2A backend in use.
+POST /analyze                 Full quality-pipeline analysis.
+POST /data-info               Lightweight dataset info (shape, columns, sample).
+GET  /.well-known/agent.json  A2A AgentCard (JSON).
+POST /a2a/{agent_id}          A2A message/send endpoint.
+
+Run
+---
+    python api_server.py            # listens on 0.0.0.0:8003
+    API_PORT=9000 python api_server.py
+
+Environment
+-----------
+API_PORT   int  Port to listen on (default 8003).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from typing import Any
+
+from fastapi import FastAPI, HTTPException, Request, Response
+from fastapi.responses import JSONResponse
+
+import a2a_agent
+import analysis_service
+from a2a_runtime import (
+    A2A_BACKEND,
+    IS_A2A_SHIM,
+    WELL_KNOWN_PATH,
+    decode_message,
+    default_registry,
+    encode_message,
+    serve_agent_card,
+)
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+# ---------------------------------------------------------------------------
+# Application factory
+# ---------------------------------------------------------------------------
+
+app = FastAPI(
+    title="Data Analyzer API",
+    description=(
+        "Data-quality analysis service exposed over REST, MCP (stdio), and A2A. "
+        "Core logic lives in analysis_service.py; all three transports delegate there."
+    ),
+    version="1.0.0",
+)
+
+
+@app.on_event("startup")
+async def _startup() -> None:
+    """Register the A2A agent so the /a2a route can dispatch locally."""
+    a2a_agent.register()
+    logger.info(
+        "data-analyzer API started — A2A backend: %s (shim=%s)", A2A_BACKEND, IS_A2A_SHIM
+    )
+
+
+# ---------------------------------------------------------------------------
+# Health
+# ---------------------------------------------------------------------------
+
+@app.get("/health")
+async def health() -> dict:
+    """Liveness probe.
+
+    Returns a small JSON dict that reports whether the real ``dcri-a2a-core``
+    package is installed or the bundled shim is active.
+    """
+    return {
+        "status": "ok",
+        "service": "data-analyzer",
+        "a2a_backend": A2A_BACKEND,
+        "a2a_shim": IS_A2A_SHIM,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Analysis endpoints
+# ---------------------------------------------------------------------------
+
+@app.post("/analyze")
+async def analyze(request: Request) -> JSONResponse:
+    """Run the full data-quality pipeline.
+
+    Request body (JSON):
+        data_content  str   Required. Raw CSV text, base64, or data-URL.
+        file_format   str   Optional (default "csv").
+        schema        dict  Optional column-type map.
+        rules         dict  Optional validation-rule map.
+        min_rows      int   Optional (default 1).
+        encoding      str   Optional (default "utf-8").
+
+    Returns:
+        Quality pipeline result dict, or ``{"error": "...", "type": "..."}``
+        if the input is invalid (always HTTP 200 — errors are in the payload
+        to match the MCP tool handler behaviour).
+    """
+    try:
+        body: dict[str, Any] = await request.json()
+    except Exception:
+        raise HTTPException(status_code=400, detail="Request body must be valid JSON")
+
+    result = analysis_service.analyze(body)
+    return JSONResponse(content=result)
+
+
+@app.post("/data-info")
+async def data_info(request: Request) -> JSONResponse:
+    """Return lightweight dataset info (shape, columns, dtypes, sample rows).
+
+    Request body (JSON):
+        data_content  str  Required.
+        file_format   str  Optional (default "csv").
+        sample_rows   int  Optional (default 5).
+        encoding      str  Optional (default "utf-8").
+
+    Returns:
+        Info dict with keys: format, shape, columns, dtypes, sample_data,
+        missing_values, duplicate_rows.
+    """
+    try:
+        body: dict[str, Any] = await request.json()
+    except Exception:
+        raise HTTPException(status_code=400, detail="Request body must be valid JSON")
+
+    result = analysis_service.get_info(body)
+    return JSONResponse(content=result)
+
+
+# ---------------------------------------------------------------------------
+# AgentCard
+# ---------------------------------------------------------------------------
+
+@app.get(WELL_KNOWN_PATH)
+async def agent_card() -> Response:
+    """Serve the A2A AgentCard at the well-known path.
+
+    Returns the canonical ``/.well-known/agent.json`` document describing this
+    agent's capabilities, supported methods, and A2A endpoint URL.
+    Clients (e.g. ``dcri-ct-graph`` pipeline nodes) discover this agent by
+    fetching this document and pointing their ``a2a_endpoint`` at the ``url``
+    field.
+    """
+    card = a2a_agent.build_card(internal_only=False)
+    body, headers, content_type = serve_agent_card(card)
+    return Response(content=body, media_type=content_type, headers=headers)
+
+
+# ---------------------------------------------------------------------------
+# A2A message/send endpoint
+# ---------------------------------------------------------------------------
+
+@app.post("/a2a/{agent_id}")
+async def a2a_message_send(agent_id: str, request: Request) -> JSONResponse:
+    """Handle an A2A ``message/send`` call for *agent_id*.
+
+    The request body must be a JSON-serialised A2A Message envelope as produced
+    by ``encode_message()``. The server decodes it, dispatches to the registered
+    agent, and returns the result wrapped in a new envelope.
+
+    Path parameters:
+        agent_id  The target agent identifier. Currently only "data-analyzer"
+                  is registered; any other value returns HTTP 404.
+
+    Returns:
+        Encoded A2A Message envelope containing the agent's result dict.
+    """
+    if agent_id != "data-analyzer":
+        raise HTTPException(
+            status_code=404,
+            detail=f"Agent {agent_id!r} not found on this server.",
+        )
+
+    try:
+        body: dict = await request.json()
+    except Exception:
+        raise HTTPException(status_code=400, detail="Request body must be a valid A2A Message JSON")
+
+    # Decode the incoming A2A envelope.
+    try:
+        payload, meta = decode_message(body)
+    except Exception as exc:
+        raise HTTPException(status_code=422, detail=f"Could not decode A2A message: {exc}")
+
+    # Retrieve the locally-registered agent and run it.
+    agent = default_registry.get(agent_id)
+    if agent is None:
+        # Shouldn't happen after startup, but be defensive.
+        raise HTTPException(
+            status_code=503,
+            detail=f"Agent {agent_id!r} is registered but not yet available.",
+        )
+
+    try:
+        result: dict = await agent.run(payload)
+    except Exception as exc:
+        logger.error("A2A agent.run error: %s", exc, exc_info=True)
+        result = {"error": str(exc), "type": "agent_error"}
+
+    # Wrap the result in an A2A response envelope.
+    response_message = encode_message(
+        result,
+        correlation_id=meta.get("correlation_id", ""),
+        cycle=meta.get("cycle", 1),
+        agent_id=agent_id,
+    )
+    return JSONResponse(content=response_message)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    import uvicorn
+
+    port = int(os.getenv("API_PORT", "8003"))
+    uvicorn.run(app, host="0.0.0.0", port=port)

--- a/api_server.py
+++ b/api_server.py
@@ -226,5 +226,7 @@ async def a2a_message_send(agent_id: str, request: Request) -> JSONResponse:
 if __name__ == "__main__":
     import uvicorn
 
-    port = int(os.getenv("API_PORT", "8003"))
+    # Cloud Run (and most PaaS) inject the port to bind via $PORT; fall back to
+    # API_PORT for local runs, then a sensible default.
+    port = int(os.getenv("PORT", os.getenv("API_PORT", "8003")))
     uvicorn.run(app, host="0.0.0.0", port=port)

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,41 @@
+# cloudbuild.yaml — Google Cloud Build configuration for the API image.
+#
+# Usage (via deploy/cloudrun.sh or manually):
+#   gcloud builds submit --config cloudbuild.yaml \
+#       --substitutions=_IMAGE=us-central1-docker.pkg.dev/MY_PROJECT/apps/data-analyzer-api:latest .
+#
+# Substitutions:
+#   _IMAGE  Full image tag, e.g. REGION-docker.pkg.dev/PROJECT/REPO/SERVICE:TAG
+#           Must be supplied at submit time (no built-in default so the build
+#           fails loudly if the caller forgets it).
+
+substitutions:
+  _IMAGE: ''   # Required — overridden at submit time via --substitutions=_IMAGE=...
+
+steps:
+  # Step 1: Build the API image using Dockerfile.api.
+  - name: 'gcr.io/cloud-builders/docker'
+    id: build
+    args:
+      - 'build'
+      - '-f'
+      - 'Dockerfile.api'
+      - '-t'
+      - '$_IMAGE'
+      - '.'
+
+  # Step 2: Push the built image to Artifact Registry.
+  - name: 'gcr.io/cloud-builders/docker'
+    id: push
+    args:
+      - 'push'
+      - '$_IMAGE'
+    waitFor:
+      - build
+
+# Declare the image so Cloud Build records it in the build provenance.
+images:
+  - '$_IMAGE'
+
+options:
+  logging: CLOUD_LOGGING_ONLY

--- a/deploy/cloudrun.sh
+++ b/deploy/cloudrun.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# deploy/cloudrun.sh — Manual deploy script for the data-analyzer API on Cloud Run.
+#
+# USAGE
+#   PROJECT_ID=my-gcp-project ./deploy/cloudrun.sh
+#
+# REQUIRED ENVIRONMENT VARIABLES
+#   PROJECT_ID   GCP project id (no default — script exits if unset).
+#
+# OPTIONAL ENVIRONMENT VARIABLES (with sensible defaults)
+#   REGION       GCP region          (default: us-central1)
+#   SERVICE      Cloud Run service   (default: data-analyzer-api)
+#   IMAGE        Full image path     (default: derived from REGION/PROJECT_ID/SERVICE)
+#
+# PREREQUISITES
+#   - gcloud CLI authenticated:  gcloud auth login  (or use a service account)
+#   - gcloud application-default credentials configured (for Cloud Build):
+#       gcloud auth application-default login
+#   - The caller needs these IAM roles on the project:
+#       roles/run.admin
+#       roles/cloudbuild.builds.editor
+#       roles/artifactregistry.admin
+#       roles/iam.serviceAccountUser          (to act as the Cloud Build SA)
+#       roles/storage.admin                   (Cloud Build source staging bucket)
+#
+# WHAT THIS SCRIPT DOES
+#   1. Validates PROJECT_ID is set.
+#   2. Ensures the Artifact Registry repository 'apps' exists (idempotent).
+#   3. Runs Cloud Build (cloudbuild.yaml) to build and push the image.
+#   4. Deploys the image to Cloud Run as a public unauthenticated service.
+#   5. Prints the resulting public URL.
+#
+# SECURITY NOTE
+#   --allow-unauthenticated makes the endpoint public. Suitable for demos.
+#   Add authentication (Cloud Run IAM or an API gateway) before exposing
+#   real sensitive data.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+: "${PROJECT_ID:?ERROR: PROJECT_ID environment variable must be set.}"
+REGION="${REGION:-us-central1}"
+SERVICE="${SERVICE:-data-analyzer-api}"
+IMAGE="${IMAGE:-${REGION}-docker.pkg.dev/${PROJECT_ID}/apps/${SERVICE}:latest}"
+
+echo "================================================================"
+echo "  Deploying data-analyzer API to Cloud Run"
+echo "  Project  : ${PROJECT_ID}"
+echo "  Region   : ${REGION}"
+echo "  Service  : ${SERVICE}"
+echo "  Image    : ${IMAGE}"
+echo "================================================================"
+
+# ---------------------------------------------------------------------------
+# Step 1: Ensure Artifact Registry repository 'apps' exists
+# ---------------------------------------------------------------------------
+echo ""
+echo "[1/3] Ensuring Artifact Registry repository 'apps' exists..."
+gcloud artifacts repositories create apps \
+    --repository-format=docker \
+    --location="${REGION}" \
+    --project="${PROJECT_ID}" \
+    --description="Container images for deployed services" \
+    2>&1 || true   # 'already exists' is not an error
+
+# Configure Docker authentication for the registry (idempotent).
+gcloud auth configure-docker "${REGION}-docker.pkg.dev" --quiet
+
+# ---------------------------------------------------------------------------
+# Step 2: Build and push the image via Cloud Build
+# ---------------------------------------------------------------------------
+echo ""
+echo "[2/3] Building and pushing image via Cloud Build..."
+# Run from the repo root (parent of this script's directory).
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+gcloud builds submit \
+    --config="${REPO_ROOT}/cloudbuild.yaml" \
+    --substitutions="_IMAGE=${IMAGE}" \
+    --project="${PROJECT_ID}" \
+    "${REPO_ROOT}"
+
+# ---------------------------------------------------------------------------
+# Step 3: Deploy to Cloud Run
+# ---------------------------------------------------------------------------
+echo ""
+echo "[3/3] Deploying to Cloud Run..."
+gcloud run deploy "${SERVICE}" \
+    --image="${IMAGE}" \
+    --region="${REGION}" \
+    --platform=managed \
+    --allow-unauthenticated \
+    --port=8080 \
+    --project="${PROJECT_ID}"
+
+# ---------------------------------------------------------------------------
+# Print the public URL
+# ---------------------------------------------------------------------------
+echo ""
+SERVICE_URL="$(gcloud run services describe "${SERVICE}" \
+    --region="${REGION}" \
+    --project="${PROJECT_ID}" \
+    --format='value(status.url)')"
+
+echo "================================================================"
+echo "  Deployment complete!"
+echo "  Public URL : ${SERVICE_URL}"
+echo ""
+echo "  Verify with:"
+echo "    curl ${SERVICE_URL}/health"
+echo ""
+echo "  Run the end-to-end check:"
+echo "    python3 scripts/e2e_a2a_check.py --url ${SERVICE_URL}"
+echo "================================================================"

--- a/developer_checklist.yaml
+++ b/developer_checklist.yaml
@@ -6,7 +6,7 @@
 project_info:
   name: Data Analyzer - Active Development
   version: 1.0.0
-  last_updated: 2025-09-28T20:00:00Z
+  last_updated: 2026-06-15T00:00:00Z
 
 # =========================================================
 # CRITICAL UPDATE - 2025-09-28 - READ THIS FIRST
@@ -802,3 +802,64 @@ ai_instructions:
     - Verify no functionality is broken
     - Check responsive design at different widths
     - Ensure loading states work properly
+
+# =========================================================
+# 2026-06-15 — REST API, MCP refactor, and A2A interface
+# =========================================================
+phase_multi_transport:
+  name: "Multi-Transport Interfaces (REST / MCP / A2A)"
+  status: DONE
+  priority: HIGH
+  completed_date: "2026-06-15T00:00:00Z"
+  notes: |
+    DONE:
+    - Implemented analysis_service.py: shared core with two functions
+      analyze(payload) and get_info(payload). All heavy imports (pandas,
+      mcp_server classes) are lazy so this module loads with stdlib only.
+    - Refactored mcp_server.py tool handlers (analyze_data, get_data_info)
+      to delegate to analysis_service via lazy import. Tool schemas and
+      MCP output format are unchanged; business logic is now in one place.
+    - Implemented a2a_agent.py: DataAnalyzerAgent (agent_id='data-analyzer'),
+      build_card(), register(). Pure stdlib at import; lazy-imports
+      analysis_service inside run(). Dispatches on operation key:
+      'analyze' -> analyze(), 'get_info'/'data_info' -> get_info(),
+      unknown -> {"error": ..., "type": "unknown_operation"}.
+    - Implemented api_server.py: FastAPI app with GET /health,
+      POST /analyze, POST /data-info, GET /.well-known/agent.json,
+      POST /a2a/{agent_id}. Registers agent on startup. Entry point
+      runs uvicorn on API_PORT (default 8003).
+    - Created tests/test_a2a_runtime.py: stdlib-only tests covering
+      encode/decode round-trip, cycle int-coercion, AgentRegistry,
+      A2AClient in-process and remote LookupError, AgentCard shape.
+      Runnable as python3 tests/test_a2a_runtime.py (no pytest needed).
+    - Created tests/test_a2a_agent.py: covers register, build_card,
+      unknown-operation path (no pandas), and full analyze/get_info
+      paths (gated with pytest.importorskip("pandas")).
+    - Created tests/test_api_server.py: covers /health and
+      /.well-known/agent.json without pandas; analysis endpoints
+      gated with pytest.importorskip("pandas").
+    - Created docs/INTEGRATION.md with curl examples for all three
+      interfaces, AgentCard discovery, a2a_runtime shim explanation,
+      and production auth note.
+    - Added "Calling this service" section to README.md linking to
+      docs/INTEGRATION.md.
+    - Added dcri-a2a-core comment line to mcp_requirements.txt.
+  tasks:
+    - id: transport_1
+      name: "Shared analysis_service.py"
+      status: DONE
+    - id: transport_2
+      name: "MCP handler delegation to analysis_service"
+      status: DONE
+    - id: transport_3
+      name: "a2a_agent.py DataAnalyzerAgent + registry helpers"
+      status: DONE
+    - id: transport_4
+      name: "api_server.py FastAPI REST + A2A gateway"
+      status: DONE
+    - id: transport_5
+      name: "Test suite: test_a2a_runtime, test_a2a_agent, test_api_server"
+      status: DONE
+    - id: transport_6
+      name: "docs/INTEGRATION.md and README.md update"
+      status: DONE

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -252,3 +252,93 @@ Environment variables:
 ## Authentication (production note)
 
 The API server does not implement authentication itself — that is a **deployment concern**. In production, place the service behind your org's API gateway or reverse proxy (NGINX, Azure API Management, etc.) and enforce bearer-token validation there. The A2A envelope metadata section is a natural place to carry a token when the real `dcri-a2a-core` package adds its HTTP transport layer.
+
+---
+
+## Deploying to Google Cloud Run (public, unauthenticated)
+
+The repository ships with a ready-to-use Cloud Run deployment path that builds a minimal API image (no Streamlit, no LLM packages) and deploys it as a fully public HTTPS endpoint.
+
+### One-command deploy
+
+```bash
+PROJECT_ID=my-gcp-project ./deploy/cloudrun.sh
+```
+
+Optional overrides (set as environment variables before the command):
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `REGION` | `us-central1` | GCP region |
+| `SERVICE` | `data-analyzer-api` | Cloud Run service name |
+| `IMAGE` | derived | Full Artifact Registry image path |
+
+The script will:
+1. Ensure the `apps` Artifact Registry repository exists (idempotent — safe to re-run).
+2. Submit a Cloud Build job (`cloudbuild.yaml`) to build `Dockerfile.api` and push the image.
+3. Deploy the image to Cloud Run with `--allow-unauthenticated --port 8080`.
+4. Print the resulting public HTTPS URL.
+
+### GitHub Actions alternative
+
+A `workflow_dispatch` workflow is provided at `.github/workflows/deploy-cloudrun.yml`. Trigger it from the GitHub Actions UI (Actions tab → "Deploy to Cloud Run" → Run workflow) and supply:
+- **project_id** (required)
+- **region** (default `us-central1`)
+- **service** (default `data-analyzer-api`)
+
+The public service URL is echoed into the job summary after a successful deploy.
+
+**Required GitHub secret — `GCP_SA_KEY`:**
+Create a GCP service account with the following IAM roles, generate a JSON key, and store it as the `GCP_SA_KEY` repository secret:
+
+| IAM Role | Purpose |
+|----------|---------|
+| `roles/run.admin` | Deploy and manage Cloud Run services |
+| `roles/cloudbuild.builds.editor` | Submit Cloud Build jobs |
+| `roles/artifactregistry.admin` | Create repositories and push images |
+| `roles/iam.serviceAccountUser` | Impersonate the Cloud Build service account |
+| `roles/storage.admin` | Cloud Build source staging bucket |
+
+**WORKLOAD IDENTITY FEDERATION is the more secure alternative.** WIF eliminates long-lived service account JSON keys by federating GitHub's OIDC token directly into GCP. See [google-github-actions/auth — Workload Identity Federation](https://github.com/google-github-actions/auth#setting-up-workload-identity-federation). Replace the `credentials_json` input with `workload_identity_provider` + `service_account` to adopt it.
+
+### Grabbing the URL after deploy
+
+```bash
+gcloud run services describe data-analyzer-api \
+    --region=us-central1 \
+    --project=MY_PROJECT \
+    --format='value(status.url)'
+```
+
+### End-to-end check
+
+After deploy, run the live proof script against the public URL:
+
+```bash
+python3 scripts/e2e_a2a_check.py --url https://data-analyzer-xxxx.run.app
+```
+
+Or via environment variable:
+
+```bash
+E2E_URL=https://data-analyzer-xxxx.run.app python3 scripts/e2e_a2a_check.py
+```
+
+The script (stdlib-only, no pip installs) verifies:
+1. `GET /health` returns `status: ok` with `a2a_backend` present.
+2. `GET /.well-known/agent.json` card `url` equals `/a2a/data-analyzer`.
+3. A base64-encoded CSV is sent via `call_agent_http()` and the response contains quality-pipeline keys (`checks`, `summary_stats`, etc.).
+
+It prints a concise PASS/FAIL summary and exits non-zero on any failure.
+
+### Security WARNING
+
+`--allow-unauthenticated` makes the `/analyze`, `/data-info`, and `/a2a/data-analyzer` endpoints reachable by **anyone on the public internet**. This is acceptable for a temporary demo or internal proof-of-concept. Before processing real patient data or any sensitive information:
+
+- Remove the `allUsers` IAM binding from the Cloud Run service.
+- Add Cloud Run IAM invoker bindings for specific identities, or place an API Gateway in front with key/JWT enforcement.
+- Consider VPC Service Controls for network-level isolation.
+
+### Note on A2A wire framing compatibility
+
+Our `/a2a/{agent_id}` endpoint speaks the **canonical DCRI JSON envelope** — a `{"payload": {...}, "metadata": {...}}` dict — which is what this repo's `a2a_runtime` shim produces and consumes. When the org installs the real `dcri-a2a-core` package (a2a-sdk based), verify whether its inbound route (`message/send`) expects the a2a-sdk JSON-RPC framing instead. The `a2a_runtime/__init__.py` indirection means no application code changes are needed — only the envelope shape at the HTTP boundary may need reconciling against the real package's router.

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -1,0 +1,254 @@
+# Integration Guide — Calling the Data Analyzer Service
+
+The Data Analyzer exposes the **same core analysis logic** through three independent interfaces. Choose the interface that fits your client:
+
+| Interface | When to use |
+|-----------|-------------|
+| **REST API** | Any HTTP client; easiest for ad-hoc scripting and CI pipelines |
+| **MCP** | Claude Desktop, Cursor, or any Model Context Protocol host |
+| **A2A** | Other DCRI agent-to-agent pipelines (`dcri-ct-graph` and siblings) |
+
+All three transports delegate to `analysis_service.py`. An error in data parsing returns `{"error": "...", "type": "..."}` in the JSON body rather than an HTTP 5xx, so clients can inspect the payload uniformly.
+
+---
+
+## 1. REST API
+
+### Running the API server
+
+```bash
+# Default port 8003
+python api_server.py
+
+# Custom port
+API_PORT=9000 python api_server.py
+```
+
+The server listens on `0.0.0.0` so it is reachable from Docker networks and remote clients.
+
+### Endpoints
+
+#### `GET /health`
+
+Liveness probe. Also reports which A2A runtime is active (real `dcri-a2a-core` or the bundled shim).
+
+```bash
+curl http://localhost:8003/health
+```
+
+```json
+{
+  "status": "ok",
+  "service": "data-analyzer",
+  "a2a_backend": "shim",
+  "a2a_shim": true
+}
+```
+
+#### `POST /analyze`
+
+Run the full data-quality pipeline (type validation, range checks, missing values, duplicate detection).
+
+```bash
+curl -X POST http://localhost:8003/analyze \
+  -H "Content-Type: application/json" \
+  -d '{
+    "data_content": "name,age,score\nAlice,30,95.5\nBob,25,88.0",
+    "file_format": "csv",
+    "schema": {"age": "int", "score": "float"},
+    "rules": {"age": {"min": 0, "max": 120}},
+    "min_rows": 1
+  }'
+```
+
+**Body fields:**
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `data_content` | string | required | Raw CSV/JSON text, base64-encoded bytes, or `data:<mime>;base64,...` data-URL |
+| `file_format` | string | `"csv"` | `"csv"`, `"json"`, `"excel"`, `"parquet"` |
+| `schema` | object | `{}` | Column-type map: `{"col": "int\|float\|str\|bool\|datetime"}` |
+| `rules` | object | `{}` | Validation rules: `{"col": {"min": 0, "max": 100, "allowed_values": [...]}}` |
+| `min_rows` | int | `1` | Minimum expected row count |
+| `encoding` | string | `"utf-8"` | Text encoding for decoding base64 content |
+
+#### `POST /data-info`
+
+Lightweight shape/column/sample info — no full quality pipeline, fast.
+
+```bash
+curl -X POST http://localhost:8003/data-info \
+  -H "Content-Type: application/json" \
+  -d '{"data_content": "name,age\nAlice,30\nBob,25", "sample_rows": 2}'
+```
+
+**Response shape:**
+```json
+{
+  "format": "csv",
+  "shape": {"rows": 2, "columns": 2},
+  "columns": ["name", "age"],
+  "dtypes": {"name": "object", "age": "int64"},
+  "sample_data": [{"name": "Alice", "age": 30}],
+  "missing_values": {"name": 0, "age": 0},
+  "duplicate_rows": 0
+}
+```
+
+---
+
+## 2. MCP (Model Context Protocol)
+
+The MCP server (`mcp_server.py`) exposes two tools: `analyze_data` and `get_data_info`. Any MCP host (Claude Desktop, Cursor, etc.) can call them.
+
+### Running the MCP server
+
+```bash
+python mcp_server.py
+```
+
+The server communicates over stdio following the MCP protocol. Configure your MCP host to launch this command.
+
+### Tool: `analyze_data`
+
+Accepts the same fields as `POST /analyze`. The MCP tool schema lists them as required/optional properties.
+
+### Tool: `get_data_info`
+
+Accepts `data_content`, `file_format`, and `sample_rows`. Returns the same shape as `POST /data-info`.
+
+Both tools delegate internally to `analysis_service.py`, so the output is byte-for-byte identical to the REST responses.
+
+---
+
+## 3. A2A (Agent-to-Agent)
+
+A2A is the inter-agent wire protocol used by DCRI pipeline systems such as `dcri-ct-graph`.
+
+### Agent identity
+
+```
+agent_id : data-analyzer
+version  : 1.0.0
+```
+
+### AgentCard discovery
+
+Every A2A-compliant agent exposes its capabilities at a well-known URL:
+
+```
+GET http://<host>:8003/.well-known/agent.json
+```
+
+Example response:
+```json
+{
+  "name": "Data Analyzer",
+  "description": "Runs data-quality checks ...",
+  "version": "1.0.0",
+  "url": "/a2a/data-analyzer",
+  "capabilities": {"streaming": false, "pushNotifications": false},
+  "methods": ["message/send", "tasks/get"],
+  "x-dcri": {"agent_id": "data-analyzer", "internal_only": false}
+}
+```
+
+Other agents (e.g. `dcri-ct-graph` pipeline nodes) point their `a2a_endpoint` configuration at:
+
+```
+https://<host>/a2a/data-analyzer
+```
+
+### Sending an A2A message
+
+Encode your payload in the canonical A2A envelope using `encode_message`:
+
+```python
+from a2a_runtime import encode_message, decode_message, A2AClient
+
+# In-process short-circuit (agent registered locally):
+import a2a_agent
+a2a_agent.register()
+
+client = A2AClient()
+result = await client.call(
+    "data-analyzer",
+    {
+        "operation": "analyze",          # or "get_info"
+        "data_content": "name,age\nAlice,30",
+        "file_format": "csv",
+    },
+    correlation_id="my-request-id",
+    cycle=1,
+)
+```
+
+Over HTTP (remote agent):
+
+```bash
+# Build the envelope manually or use the SDK:
+curl -X POST http://<host>:8003/a2a/data-analyzer \
+  -H "Content-Type: application/json" \
+  -d '{
+    "payload": {
+      "operation": "analyze",
+      "data_content": "name,age\nAlice,30",
+      "file_format": "csv"
+    },
+    "metadata": {
+      "correlation_id": "abc-123",
+      "cycle": 1,
+      "agent_id": "data-analyzer"
+    }
+  }'
+```
+
+**Supported `operation` values:**
+
+| Value | Description |
+|-------|-------------|
+| `"analyze"` (default) | Full quality pipeline |
+| `"get_info"` or `"data_info"` | Lightweight shape/column info |
+
+The response is itself an A2A envelope. Decode with `decode_message(response_json)` to extract the result dict.
+
+---
+
+## A2A runtime — shim vs real package
+
+`a2a_runtime/` is a thin indirection layer:
+
+- If `dcri-a2a-core` is installed (`pip install dcri-a2a-core`), the **real versioned wire contract** is used.
+- Otherwise, the **bundled pure-stdlib shim** (`a2a_runtime/_shim.py`) provides identical names and call signatures.
+
+The `GET /health` response and AgentCard `x-dcri` section both expose `a2a_backend` and `a2a_shim` so operators can see at a glance which runtime is active.
+
+To upgrade to the real package:
+```bash
+pip install dcri-a2a-core
+# No code changes required — a2a_runtime/__init__.py prefers the real package automatically.
+```
+
+---
+
+## Running the API server
+
+```bash
+# Default port 8003
+python api_server.py
+
+# Override port
+API_PORT=9000 python api_server.py
+```
+
+Environment variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `API_PORT` | `8003` | TCP port for the REST + A2A HTTP server |
+
+---
+
+## Authentication (production note)
+
+The API server does not implement authentication itself — that is a **deployment concern**. In production, place the service behind your org's API gateway or reverse proxy (NGINX, Azure API Management, etc.) and enforce bearer-token validation there. The A2A envelope metadata section is a natural place to carry a token when the real `dcri-a2a-core` package adds its HTTP transport layer.

--- a/mcp_requirements.txt
+++ b/mcp_requirements.txt
@@ -6,3 +6,4 @@ python-multipart>=0.0.6
 uvicorn>=0.20.0
 fastapi>=0.100.0
 pydantic>=2.0.0
+# dcri-a2a-core  # optional: real A2A wire contract (else a2a_runtime shim is used)

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -792,112 +792,47 @@ async def handle_list_tools() -> list[types.Tool]:
 
 @app.call_tool()
 async def handle_call_tool(name: str, arguments: dict) -> list[types.TextContent]:
-    """Handle tool calls"""
-    
+    """Handle tool calls by delegating to the shared analysis_service module.
+
+    Both ``analyze_data`` and ``get_data_info`` delegate to ``analysis_service``
+    so the business logic is defined in exactly one place and all three transport
+    layers (REST, MCP, A2A) stay in sync automatically.
+    """
+    # Lazy import avoids a circular dependency at module load time.
+    import analysis_service  # noqa: PLC0415
+
     if name == "analyze_data":
-        try:
-            data_content = arguments["data_content"]
-            file_format = arguments.get("file_format", "csv")
-            schema = arguments.get("schema", {})
-            rules = arguments.get("rules", {})
-            min_rows = arguments.get("min_rows", 1)
-            encoding = arguments.get("encoding", "utf-8")
-            
-            # Try to detect if content is base64 encoded
-            try:
-                if data_content.startswith("data:"):
-                    # Handle data URLs
-                    header, data = data_content.split(",", 1)
-                    data_content = base64.b64decode(data).decode(encoding)
-                elif len(data_content) % 4 == 0 and all(c in "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=" for c in data_content):
-                    # Might be base64
-                    try:
-                        decoded = base64.b64decode(data_content).decode(encoding)
-                        if "," in decoded or "\t" in decoded:  # Basic delimiter check
-                            data_content = decoded
-                    except:
-                        pass  # Not base64, use as-is
-            except:
-                pass  # Use content as-is
-            
-            # Load data using the extensible loader
-            df = DataLoader.load_data(data_content, file_format)
-            
-            # Run quality pipeline
-            pipeline = QualityPipeline(df, schema, rules)
-            results = pipeline.run_all_checks(min_rows)
-            
-            return [
-                types.TextContent(
-                    type="text",
-                    text=json.dumps(results, indent=2, default=str)
-                )
-            ]
-            
-        except Exception as e:
-            return [
-                types.TextContent(
-                    type="text",
-                    text=json.dumps({
-                        "error": str(e),
-                        "type": "analysis_error"
-                    }, indent=2)
-                )
-            ]
-    
+        payload = {
+            "data_content": arguments.get("data_content", ""),
+            "file_format": arguments.get("file_format", "csv"),
+            "schema": arguments.get("schema", {}),
+            "rules": arguments.get("rules", {}),
+            "min_rows": arguments.get("min_rows", 1),
+            "encoding": arguments.get("encoding", "utf-8"),
+        }
+        result = analysis_service.analyze(payload)
+        return [
+            types.TextContent(
+                type="text",
+                text=json.dumps(result, indent=2, default=str),
+            )
+        ]
+
     elif name == "get_data_info":
-        try:
-            data_content = arguments["data_content"]
-            file_format = arguments.get("file_format", "csv")
-            sample_rows = arguments.get("sample_rows", 5)
-            
-            # Handle base64 encoding
-            try:
-                if data_content.startswith("data:"):
-                    header, data = data_content.split(",", 1)
-                    data_content = base64.b64decode(data).decode('utf-8')
-                elif len(data_content) % 4 == 0:
-                    try:
-                        decoded = base64.b64decode(data_content).decode('utf-8')
-                        if "," in decoded or "\t" in decoded:
-                            data_content = decoded
-                    except:
-                        pass
-            except:
-                pass
-            
-            # Load data using the extensible loader
-            df = DataLoader.load_data(data_content, file_format)
-            
-            # Get basic info
-            info = {
-                "format": file_format,
-                "shape": {"rows": len(df), "columns": len(df.columns)},
-                "columns": list(df.columns),
-                "dtypes": {col: str(dtype) for col, dtype in df.dtypes.items()},
-                "sample_data": df.head(sample_rows).to_dict(orient='records'),
-                "missing_values": df.isnull().sum().to_dict(),
-                "duplicate_rows": int(df.duplicated().sum())
-            }
-            
-            return [
-                types.TextContent(
-                    type="text",
-                    text=json.dumps(info, indent=2, default=str)
-                )
-            ]
-            
-        except Exception as e:
-            return [
-                types.TextContent(
-                    type="text",
-                    text=json.dumps({
-                        "error": str(e),
-                        "type": "info_error"
-                    }, indent=2)
-                )
-            ]
-    
+        payload = {
+            "data_content": arguments.get("data_content", ""),
+            "file_format": arguments.get("file_format", "csv"),
+            "sample_rows": arguments.get("sample_rows", 5),
+            "encoding": arguments.get("encoding", "utf-8"),
+        }
+        result = analysis_service.get_info(payload)
+        return [
+            types.TextContent(
+                type="text",
+                text=json.dumps(result, indent=2, default=str),
+            )
+        ]
+
     else:
         raise ValueError(f"Unknown tool: {name}")
 

--- a/requirements-api.txt
+++ b/requirements-api.txt
@@ -1,0 +1,14 @@
+# API server runtime dependencies — no Streamlit, no LLM packages.
+# These are the only packages needed for the api_server:app image deployed to Cloud Run.
+# Pin style matches existing requirements.txt (>= lower bound, no upper cap).
+
+fastapi>=0.104.0
+uvicorn[standard]>=0.24.0
+pydantic>=2.0.0
+python-multipart>=0.0.6
+pandas>=2.0.0
+numpy>=1.24.0
+chardet>=5.2.0
+openpyxl>=3.1.2
+xlrd>=2.0.1
+pyarrow>=14.0.0

--- a/scripts/e2e_a2a_check.py
+++ b/scripts/e2e_a2a_check.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+"""
+scripts/e2e_a2a_check.py — Live end-to-end proof that the deployed
+data-analyzer Cloud Run service is reachable and returns correct results.
+
+STDLIB ONLY — no pandas, no requests, no third-party packages.
+
+Usage
+-----
+    python3 scripts/e2e_a2a_check.py --url https://<service-url>
+    E2E_URL=https://<service-url> python3 scripts/e2e_a2a_check.py
+
+Exit codes
+----------
+    0  All checks passed.
+    1  One or more checks failed (detailed FAIL messages printed).
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from typing import Any, Tuple
+
+# ---------------------------------------------------------------------------
+# Tiny HTTP helpers (urllib only)
+# ---------------------------------------------------------------------------
+
+
+def _get(url: str, *, timeout: float = 30.0) -> Tuple[int, dict | str]:
+    """GET *url* and return (status_code, parsed_body).
+
+    Body is parsed as JSON if Content-Type is application/json, otherwise
+    returned as a raw string.
+    """
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as resp:
+            raw = resp.read().decode("utf-8")
+            ct = resp.headers.get_content_type() or ""
+            if "json" in ct:
+                return resp.status, json.loads(raw)
+            return resp.status, raw
+    except urllib.error.HTTPError as exc:
+        raw = exc.read().decode("utf-8", "replace") if exc.fp else ""
+        try:
+            return exc.code, json.loads(raw)
+        except Exception:
+            return exc.code, raw
+    except urllib.error.URLError as exc:
+        raise SystemExit(f"FATAL: Cannot reach {url!r}: {exc.reason}") from exc
+
+
+def _post_json(url: str, body: dict, *, timeout: float = 60.0) -> Tuple[int, dict | str]:
+    """POST *body* as JSON to *url* and return (status_code, parsed_body)."""
+    data = json.dumps(body).encode("utf-8")
+    headers = {"Content-Type": "application/json", "Accept": "application/json"}
+    req = urllib.request.Request(url, data=data, method="POST", headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            raw = resp.read().decode("utf-8")
+            try:
+                return resp.status, json.loads(raw)
+            except Exception:
+                return resp.status, raw
+    except urllib.error.HTTPError as exc:
+        raw = exc.read().decode("utf-8", "replace") if exc.fp else ""
+        try:
+            return exc.code, json.loads(raw)
+        except Exception:
+            return exc.code, raw
+    except urllib.error.URLError as exc:
+        raise SystemExit(f"FATAL: Cannot reach {url!r}: {exc.reason}") from exc
+
+
+# ---------------------------------------------------------------------------
+# Check helpers
+# ---------------------------------------------------------------------------
+
+_failures: list[str] = []
+_passes: list[str] = []
+
+
+def _ok(label: str, detail: str = "") -> None:
+    msg = f"  PASS  {label}"
+    if detail:
+        msg += f" — {detail}"
+    print(msg)
+    _passes.append(label)
+
+
+def _fail(label: str, detail: str = "") -> None:
+    msg = f"  FAIL  {label}"
+    if detail:
+        msg += f" — {detail}"
+    print(msg)
+    _failures.append(f"{label}: {detail}")
+
+
+def _assert(condition: bool, label: str, detail: str = "") -> bool:
+    if condition:
+        _ok(label, detail)
+    else:
+        _fail(label, detail)
+    return condition
+
+
+# ---------------------------------------------------------------------------
+# Check 1 — GET /health
+# ---------------------------------------------------------------------------
+
+def check_health(base_url: str) -> None:
+    print("\n[1/3] GET /health")
+    url = f"{base_url}/health"
+    status, body = _get(url)
+    if not _assert(status == 200, "/health returns HTTP 200", f"got {status}"):
+        return
+    if not isinstance(body, dict):
+        _fail("/health body is JSON dict", f"got {type(body).__name__}: {body!r:.80}")
+        return
+    _assert(body.get("status") == "ok", '/health body.status == "ok"', f"got {body.get('status')!r}")
+    _assert("a2a_backend" in body, "/health body contains 'a2a_backend'", str(body))
+
+
+# ---------------------------------------------------------------------------
+# Check 2 — GET /.well-known/agent.json
+# ---------------------------------------------------------------------------
+
+def check_agent_card(base_url: str) -> None:
+    print("\n[2/3] GET /.well-known/agent.json")
+    url = f"{base_url}/.well-known/agent.json"
+    status, body = _get(url)
+    if not _assert(status == 200, "/.well-known/agent.json returns HTTP 200", f"got {status}"):
+        return
+    if not isinstance(body, dict):
+        _fail("agent.json body is JSON dict", f"got {type(body).__name__}")
+        return
+    expected_url = "/a2a/data-analyzer"
+    card_url: Any = body.get("url")
+    _assert(
+        card_url == expected_url,
+        f"agent.json url == {expected_url!r}",
+        f"got {card_url!r}",
+    )
+    _assert("name" in body, "agent.json has 'name' field", str(body.get("name")))
+    _assert("version" in body, "agent.json has 'version' field", str(body.get("version")))
+
+
+# ---------------------------------------------------------------------------
+# Check 3 — A2A call via a2a_runtime.http_client.call_agent_http
+# ---------------------------------------------------------------------------
+
+def check_a2a_call(base_url: str) -> None:
+    """Build a tiny CSV, base64-encode it, and call the A2A endpoint.
+
+    The import of call_agent_http is done here so the rest of the script
+    still runs (and checks 1 & 2 still report) if the repo is not on sys.path.
+    """
+    print("\n[3/3] A2A call via a2a_runtime.http_client.call_agent_http")
+
+    # Ensure the repo root is importable.
+    _repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    if _repo_root not in sys.path:
+        sys.path.insert(0, _repo_root)
+
+    try:
+        from a2a_runtime.http_client import call_agent_http  # noqa: PLC0415
+    except ImportError as exc:
+        _fail("import a2a_runtime.http_client", str(exc))
+        return
+
+    # Tiny CSV with an intentional age outlier (200) to trigger a quality flag.
+    csv_text = "id,age\n1,30\n2,40\n3,200\n"
+    b64_csv = base64.b64encode(csv_text.encode("utf-8")).decode("ascii")
+
+    payload = {
+        "operation": "analyze",
+        "data_content": b64_csv,
+        "file_format": "csv",
+    }
+
+    try:
+        result = call_agent_http(
+            base_url,
+            "data-analyzer",
+            payload,
+            correlation_id="e2e-1",
+        )
+    except Exception as exc:
+        _fail("call_agent_http completes without exception", str(exc))
+        return
+
+    if not _assert(isinstance(result, dict), "A2A response is a dict", type(result).__name__):
+        return
+
+    # The quality pipeline always returns at least one of these top-level keys.
+    EXPECTED_KEYS = {"checks", "summary_stats", "row_count", "error"}
+    found_keys = EXPECTED_KEYS & set(result.keys())
+    _assert(
+        bool(found_keys),
+        f"result contains quality-pipeline keys (one of {sorted(EXPECTED_KEYS)})",
+        f"actual keys: {sorted(result.keys())}",
+    )
+
+    # Ensure it is not a pure error response.
+    _assert(
+        "error" not in result or "checks" in result or "row_count" in result,
+        "result is not an error-only response",
+        str(result)[:120],
+    )
+
+    print(f"       result keys: {sorted(result.keys())}")
+
+
+# ---------------------------------------------------------------------------
+# curl example
+# ---------------------------------------------------------------------------
+
+def print_curl_example(base_url: str) -> None:
+    csv_text = "id,age\n1,30\n2,40\n3,200\n"
+    b64_csv = base64.b64encode(csv_text.encode("utf-8")).decode("ascii")
+    payload = json.dumps({"data_content": b64_csv, "file_format": "csv"}, indent=2)
+    print("\n---- curl example (POST /analyze) ----")
+    print(f"curl -s -X POST {base_url}/analyze \\")
+    print("     -H 'Content-Type: application/json' \\")
+    print(f"     -d '{payload}'")
+    print("--------------------------------------")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def _parse_args() -> str:
+    """Return the service base URL from --url or $E2E_URL."""
+    parser = argparse.ArgumentParser(
+        description="Live end-to-end A2A check for the deployed data-analyzer service."
+    )
+    parser.add_argument(
+        "--url",
+        default=os.environ.get("E2E_URL", ""),
+        help="Base URL of the deployed service (e.g. https://data-analyzer-xxxx.run.app). "
+             "Also read from $E2E_URL.",
+    )
+    args = parser.parse_args()
+    if not args.url:
+        parser.error("Provide --url or set the E2E_URL environment variable.")
+    return args.url.rstrip("/")
+
+
+def main() -> None:
+    base_url = _parse_args()
+    print(f"Target: {base_url}")
+
+    check_health(base_url)
+    check_agent_card(base_url)
+    check_a2a_call(base_url)
+    print_curl_example(base_url)
+
+    # Summary
+    total = len(_passes) + len(_failures)
+    print(f"\n{'='*50}")
+    if not _failures:
+        print(f"PASS — all {total} checks passed.")
+        print("="*50)
+        sys.exit(0)
+    else:
+        print(f"FAIL — {len(_failures)}/{total} checks failed:")
+        for f in _failures:
+            print(f"  - {f}")
+        print("="*50)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_a2a_agent.py
+++ b/tests/test_a2a_agent.py
@@ -1,0 +1,209 @@
+"""
+tests/test_a2a_agent.py — Tests for the DataAnalyzerAgent A2A wrapper.
+
+Tests that need real analysis (pandas + core classes) are gated with
+``pytest.importorskip("pandas")``.  The unknown-operation error path is
+tested without pandas because it short-circuits before any data loading.
+
+Run: ``pytest tests/test_a2a_agent.py``
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+
+import pytest
+
+# Ensure repo root on path.
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.dirname(_HERE)
+if _ROOT not in sys.path:
+    sys.path.insert(0, _ROOT)
+
+from a2a_runtime import AgentRegistry, default_registry
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+def test_register_populates_default_registry():
+    """register() places a DataAnalyzerAgent into default_registry."""
+    import a2a_agent
+
+    # Clear any prior registration to make this test independent.
+    default_registry.clear()
+    a2a_agent.register()
+
+    agent = default_registry.get("data-analyzer")
+    assert agent is not None, "DataAnalyzerAgent should be registered"
+    assert agent.agent_id == "data-analyzer"
+
+
+def test_register_is_idempotent():
+    """Calling register() twice does not raise and leaves a valid agent."""
+    import a2a_agent
+
+    default_registry.clear()
+    a2a_agent.register()
+    a2a_agent.register()  # second call — must not raise
+
+    assert default_registry.get("data-analyzer") is not None
+
+
+def test_register_into_custom_registry():
+    """register(registry=...) targets a user-supplied registry, not the default."""
+    import a2a_agent
+
+    custom_reg = AgentRegistry()
+    default_registry.clear()
+    a2a_agent.register(registry=custom_reg)
+
+    assert custom_reg.get("data-analyzer") is not None
+    # Must NOT have registered into the default registry.
+    assert default_registry.get("data-analyzer") is None
+
+
+# ---------------------------------------------------------------------------
+# build_card
+# ---------------------------------------------------------------------------
+
+def test_build_card_url_matches_agent_id():
+    """build_card() returns a card whose url contains the agent id."""
+    import a2a_agent
+
+    card = a2a_agent.build_card(internal_only=False)
+    assert "data-analyzer" in card["url"]
+
+
+def test_build_card_internal_only_default_is_false():
+    """build_card() with no arguments defaults to internal_only=False."""
+    import a2a_agent
+
+    card = a2a_agent.build_card()
+    # The x-dcri extension carries the flag.
+    assert card.get("x-dcri", {}).get("internal_only") is False
+
+
+def test_build_card_can_be_internal():
+    """build_card(internal_only=True) sets the flag in x-dcri."""
+    import a2a_agent
+
+    card = a2a_agent.build_card(internal_only=True)
+    assert card.get("x-dcri", {}).get("internal_only") is True
+
+
+# ---------------------------------------------------------------------------
+# Unknown-operation error (no pandas needed)
+# ---------------------------------------------------------------------------
+
+def test_unknown_operation_returns_error_dict():
+    """DataAnalyzerAgent.run returns an error dict for unknown operations."""
+    import a2a_agent
+
+    agent = a2a_agent.DataAnalyzerAgent()
+    result = _run(agent.run({"operation": "fly-to-the-moon"}))
+
+    assert "error" in result, "Expected an 'error' key in result"
+    assert result.get("type") == "unknown_operation"
+
+
+def test_missing_operation_defaults_to_analyze():
+    """When 'operation' key is absent, the agent defaults to 'analyze'.
+
+    Since pandas is not available in offline mode the call will return an
+    error dict — but it must NOT return 'unknown_operation'; it must attempt
+    the analyze path (which fails for a different reason: missing deps).
+    """
+    import a2a_agent
+
+    agent = a2a_agent.DataAnalyzerAgent()
+    # No data_content either — analysis_service.analyze returns a validation error.
+    result = _run(agent.run({}))
+
+    assert result.get("type") != "unknown_operation", (
+        "Missing 'operation' should default to 'analyze', not 'unknown_operation'"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Full analysis path (requires pandas)
+# ---------------------------------------------------------------------------
+
+pandas = pytest.importorskip("pandas", reason="pandas not installed — skipping analysis tests")
+
+
+SAMPLE_CSV = "name,age,score\nAlice,30,95.5\nBob,25,88.0\nCarol,35,72.0\n"
+
+
+def test_agent_run_analyze():
+    """DataAnalyzerAgent.run with operation='analyze' returns quality results."""
+    import a2a_agent
+
+    agent = a2a_agent.DataAnalyzerAgent()
+    payload = {
+        "operation": "analyze",
+        "data_content": SAMPLE_CSV,
+        "file_format": "csv",
+    }
+    result = _run(agent.run(payload))
+
+    assert isinstance(result, dict)
+    # The quality pipeline result should not be a plain error.
+    assert "error" not in result or result.get("type") != "analysis_error", (
+        f"Got unexpected error: {result}"
+    )
+
+
+def test_agent_run_get_info():
+    """DataAnalyzerAgent.run with operation='get_info' returns shape/column info."""
+    import a2a_agent
+
+    agent = a2a_agent.DataAnalyzerAgent()
+    payload = {
+        "operation": "get_info",
+        "data_content": SAMPLE_CSV,
+        "file_format": "csv",
+    }
+    result = _run(agent.run(payload))
+
+    assert isinstance(result, dict)
+    assert "shape" in result, f"Expected 'shape' key; got: {result}"
+    assert result["shape"]["rows"] == 3
+    assert result["shape"]["columns"] == 3
+
+
+def test_agent_run_data_info_alias():
+    """'data_info' is an accepted alias for 'get_info'."""
+    import a2a_agent
+
+    agent = a2a_agent.DataAnalyzerAgent()
+    payload = {
+        "operation": "data_info",
+        "data_content": SAMPLE_CSV,
+        "file_format": "csv",
+    }
+    result = _run(agent.run(payload))
+
+    assert "shape" in result, f"Expected shape in result; got: {result}"
+
+
+def test_agent_run_missing_data_content():
+    """analyze with no data_content returns a validation error dict, not a raise."""
+    import a2a_agent
+
+    agent = a2a_agent.DataAnalyzerAgent()
+    result = _run(agent.run({"operation": "analyze"}))
+
+    assert "error" in result
+    # Must not propagate as an unhandled exception.

--- a/tests/test_a2a_runtime.py
+++ b/tests/test_a2a_runtime.py
@@ -1,0 +1,262 @@
+"""
+tests/test_a2a_runtime.py — STDLIB-ONLY tests for the a2a_runtime package.
+
+These tests MUST pass under plain ``python3`` with zero pip-installed packages.
+They exercise:
+  - encode_message / decode_message round-trip + cycle int-coercion
+  - AgentRegistry: register, get, clear
+  - A2AClient in-process dispatch (short-circuit, no network)
+  - A2AClient remote LookupError when no remote_sender is configured
+  - build_agent_card / serve_agent_card output shape
+  - AGENT_PATH_TEMPLATE / WELL_KNOWN_PATH constants
+
+No pandas, no fastapi, no mcp — only a2a_runtime (stdlib shim or real package).
+
+Run with pytest: ``pytest tests/test_a2a_runtime.py``
+Run standalone:  ``python3 tests/test_a2a_runtime.py``
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+import os
+
+# Ensure repo root is on sys.path when run as a script.
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.dirname(_HERE)
+if _ROOT not in sys.path:
+    sys.path.insert(0, _ROOT)
+
+from a2a_runtime import (
+    A2A_BACKEND,
+    A2A_IMPLEMENTED_METHODS,
+    A2A_MINIMAL_CAPABILITIES,
+    AGENT_PATH_TEMPLATE,
+    WELL_KNOWN_PATH,
+    AgentRegistry,
+    A2AClient,
+    IS_A2A_SHIM,
+    build_agent_card,
+    decode_message,
+    default_registry,
+    encode_message,
+    serve_agent_card,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _run(coro):
+    """Run a coroutine in a new event loop (works without pytest-asyncio)."""
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+# ---------------------------------------------------------------------------
+# encode_message / decode_message
+# ---------------------------------------------------------------------------
+
+def test_encode_decode_round_trip():
+    """Payload survives encode -> decode without data loss."""
+    payload = {"data_content": "col_a,col_b\n1,2", "file_format": "csv"}
+    msg = encode_message(payload, correlation_id="corr-001", cycle=1, agent_id="data-analyzer")
+
+    assert isinstance(msg, dict), "encode_message must return a dict"
+    assert "payload" in msg
+    assert "metadata" in msg
+
+    recovered_payload, meta = decode_message(msg)
+    assert recovered_payload == payload
+    assert meta["correlation_id"] == "corr-001"
+    assert meta["cycle"] == 1
+    assert meta["agent_id"] == "data-analyzer"
+
+
+def test_cycle_is_coerced_to_int():
+    """decode_message must return ``cycle`` as int, even if stored as float."""
+    payload = {"x": 1}
+    msg = encode_message(payload, correlation_id="corr-002", cycle=3)
+    # Manually corrupt cycle to float to simulate protobuf / JSON round-trip.
+    msg["metadata"]["cycle"] = 3.0
+
+    _, meta = decode_message(msg)
+    assert isinstance(meta["cycle"], int), "cycle must be int after decode"
+    assert meta["cycle"] == 3
+
+
+def test_encode_empty_payload():
+    """encode_message handles empty dict without raising."""
+    msg = encode_message({}, correlation_id="corr-003", cycle=1)
+    payload, meta = decode_message(msg)
+    assert payload == {}
+    assert meta["correlation_id"] == "corr-003"
+
+
+def test_decode_missing_metadata_fields():
+    """decode_message returns sensible defaults when metadata keys are absent."""
+    bare_msg = {"payload": {"a": 1}, "metadata": {}}
+    payload, meta = decode_message(bare_msg)
+    assert payload == {"a": 1}
+    assert meta["correlation_id"] is None
+    assert meta["cycle"] == 1   # default
+
+
+def test_encode_non_dict_payload_raises():
+    """encode_message raises TypeError for non-dict, non-model-dump payloads."""
+    try:
+        encode_message("not-a-dict", correlation_id="c", cycle=1)  # type: ignore[arg-type]
+        assert False, "Expected TypeError"
+    except TypeError:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# AgentRegistry
+# ---------------------------------------------------------------------------
+
+class _DummyAgent:
+    agent_id = "dummy"
+
+    async def run(self, payload: dict) -> dict:
+        return {"echo": payload}
+
+
+def test_registry_register_and_get():
+    """register + get returns the same agent instance."""
+    reg = AgentRegistry()
+    agent = _DummyAgent()
+    reg.register(agent)
+    assert reg.get("dummy") is agent
+
+
+def test_registry_get_missing_returns_none():
+    """get on an absent agent_id returns None."""
+    reg = AgentRegistry()
+    assert reg.get("no-such-agent") is None
+
+
+def test_registry_clear():
+    """clear removes all registered agents."""
+    reg = AgentRegistry()
+    reg.register(_DummyAgent())
+    reg.clear()
+    assert reg.get("dummy") is None
+
+
+def test_registry_overwrite_is_idempotent():
+    """Registering the same agent_id twice replaces the old entry."""
+    reg = AgentRegistry()
+    a1 = _DummyAgent()
+    a2 = _DummyAgent()
+    reg.register(a1)
+    reg.register(a2)
+    assert reg.get("dummy") is a2
+
+
+# ---------------------------------------------------------------------------
+# A2AClient — in-process dispatch
+# ---------------------------------------------------------------------------
+
+def test_a2a_client_in_process_call():
+    """A2AClient.call dispatches to a locally registered agent."""
+    reg = AgentRegistry()
+    reg.register(_DummyAgent())
+    client = A2AClient(registry=reg)
+
+    result = _run(
+        client.call("dummy", {"hello": "world"}, correlation_id="corr-010", cycle=1)
+    )
+    assert result == {"echo": {"hello": "world"}}
+
+
+def test_a2a_client_remote_lookup_error():
+    """A2AClient.call raises LookupError for unknown agent with no remote_sender."""
+    reg = AgentRegistry()
+    client = A2AClient(registry=reg)
+
+    try:
+        _run(client.call("unknown-agent", {}, correlation_id="c", cycle=1))
+        assert False, "Expected LookupError"
+    except LookupError:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# AgentCard
+# ---------------------------------------------------------------------------
+
+def test_build_agent_card_url():
+    """build_agent_card produces a url matching AGENT_PATH_TEMPLATE."""
+    card = build_agent_card(
+        "data-analyzer",
+        "Data Analyzer",
+        "Test agent",
+        version="1.0.0",
+        internal_only=False,
+    )
+    expected_url = AGENT_PATH_TEMPLATE.format(agent_id="data-analyzer")
+    assert card["url"] == expected_url, f"Expected {expected_url!r}, got {card['url']!r}"
+
+
+def test_build_agent_card_shape():
+    """build_agent_card returns all required top-level keys."""
+    card = build_agent_card(
+        "data-analyzer",
+        "Data Analyzer",
+        "Description",
+        version="1.0.0",
+    )
+    for key in ("name", "description", "version", "url", "capabilities", "methods"):
+        assert key in card, f"Missing key {key!r} in AgentCard"
+
+
+def test_serve_agent_card_returns_json():
+    """serve_agent_card output is valid JSON and content-type is application/json."""
+    card = build_agent_card("data-analyzer", "DA", "desc", version="1.0.0")
+    body, headers, content_type = serve_agent_card(card)
+    assert content_type == "application/json"
+    parsed = json.loads(body)   # must not raise
+    assert parsed["url"] == AGENT_PATH_TEMPLATE.format(agent_id="data-analyzer")
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+def test_well_known_path_starts_with_slash():
+    assert WELL_KNOWN_PATH.startswith("/"), "WELL_KNOWN_PATH must be an absolute path"
+
+
+def test_agent_path_template_contains_placeholder():
+    assert "{agent_id}" in AGENT_PATH_TEMPLATE
+
+
+def test_a2a_backend_is_string():
+    assert isinstance(A2A_BACKEND, str) and A2A_BACKEND, "A2A_BACKEND must be a non-empty string"
+
+
+def test_is_a2a_shim_is_bool():
+    assert isinstance(IS_A2A_SHIM, bool)
+
+
+# ---------------------------------------------------------------------------
+# Standalone runner (no pytest required)
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    _tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    passed = 0
+    failed = 0
+    for fn in _tests:
+        try:
+            fn()
+            print(f"  PASS  {fn.__name__}")
+            passed += 1
+        except Exception as exc:
+            print(f"  FAIL  {fn.__name__}: {exc}")
+            failed += 1
+    print(f"\n{passed} passed, {failed} failed out of {passed + failed} tests.")
+    sys.exit(0 if failed == 0 else 1)

--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -1,0 +1,231 @@
+"""
+tests/test_api_server.py — Tests for api_server.py FastAPI endpoints.
+
+All tests use pytest.importorskip("fastapi") so the file degrades gracefully
+when FastAPI is not installed (offline / minimal environments).
+
+Tests that do NOT require pandas:
+  - GET /health
+  - GET /.well-known/agent.json
+
+Tests that require pandas are gated with a further importorskip.
+
+Run: ``pytest tests/test_api_server.py``
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+import pytest
+
+# Ensure repo root on path.
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.dirname(_HERE)
+if _ROOT not in sys.path:
+    sys.path.insert(0, _ROOT)
+
+# Gate the entire module on fastapi being present.
+fastapi = pytest.importorskip("fastapi", reason="fastapi not installed — skipping API tests")
+
+from fastapi.testclient import TestClient  # noqa: E402 (after importorskip)
+
+import api_server  # noqa: E402
+
+
+@pytest.fixture(scope="module")
+def client():
+    """Return a TestClient wrapping the FastAPI app.
+
+    We trigger the startup event so the A2A agent is registered before tests run.
+    """
+    with TestClient(api_server.app) as c:
+        yield c
+
+
+# ---------------------------------------------------------------------------
+# /health
+# ---------------------------------------------------------------------------
+
+def test_health_status_ok(client):
+    """GET /health returns HTTP 200 with status='ok'."""
+    response = client.get("/health")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "ok"
+
+
+def test_health_service_name(client):
+    """GET /health reports service='data-analyzer'."""
+    data = client.get("/health").json()
+    assert data["service"] == "data-analyzer"
+
+
+def test_health_a2a_backend_present(client):
+    """GET /health includes the a2a_backend field."""
+    data = client.get("/health").json()
+    assert "a2a_backend" in data
+    assert isinstance(data["a2a_backend"], str)
+
+
+def test_health_a2a_shim_is_bool(client):
+    """GET /health a2a_shim field is a boolean."""
+    data = client.get("/health").json()
+    assert "a2a_shim" in data
+    assert isinstance(data["a2a_shim"], bool)
+
+
+# ---------------------------------------------------------------------------
+# /.well-known/agent.json
+# ---------------------------------------------------------------------------
+
+def test_agent_card_status(client):
+    """GET /.well-known/agent.json returns HTTP 200."""
+    response = client.get("/.well-known/agent.json")
+    assert response.status_code == 200
+
+
+def test_agent_card_content_type(client):
+    """AgentCard response has application/json content type."""
+    response = client.get("/.well-known/agent.json")
+    assert "application/json" in response.headers.get("content-type", "")
+
+
+def test_agent_card_url_field(client):
+    """AgentCard url field points at /a2a/data-analyzer."""
+    data = client.get("/.well-known/agent.json").json()
+    assert data["url"] == "/a2a/data-analyzer"
+
+
+def test_agent_card_required_fields(client):
+    """AgentCard contains all required top-level fields."""
+    data = client.get("/.well-known/agent.json").json()
+    for field in ("name", "description", "version", "url", "capabilities", "methods"):
+        assert field in data, f"AgentCard missing field {field!r}"
+
+
+def test_agent_card_not_internal_only(client):
+    """AgentCard served from the public endpoint has internal_only=False."""
+    data = client.get("/.well-known/agent.json").json()
+    dcri = data.get("x-dcri", {})
+    assert dcri.get("internal_only") is False
+
+
+# ---------------------------------------------------------------------------
+# /analyze and /data-info — require pandas
+# ---------------------------------------------------------------------------
+
+pandas = pytest.importorskip(
+    "pandas",
+    reason="pandas not installed — skipping analysis endpoint tests",
+)
+
+SAMPLE_CSV = "name,age,score\nAlice,30,95.5\nBob,25,88.0\nCarol,35,72.0\n"
+
+
+def test_analyze_endpoint_returns_200(client):
+    """POST /analyze with valid CSV returns HTTP 200."""
+    response = client.post(
+        "/analyze",
+        json={"data_content": SAMPLE_CSV, "file_format": "csv"},
+    )
+    assert response.status_code == 200
+
+
+def test_analyze_endpoint_returns_dict(client):
+    """POST /analyze result body is a JSON object."""
+    response = client.post(
+        "/analyze",
+        json={"data_content": SAMPLE_CSV, "file_format": "csv"},
+    )
+    data = response.json()
+    assert isinstance(data, dict)
+
+
+def test_analyze_missing_data_content(client):
+    """POST /analyze with no data_content returns a JSON error dict, not 5xx."""
+    response = client.post("/analyze", json={})
+    assert response.status_code == 200     # service returns error in body
+    data = response.json()
+    assert "error" in data
+
+
+def test_data_info_endpoint_shape(client):
+    """POST /data-info returns shape, columns, and sample_data."""
+    response = client.post(
+        "/data-info",
+        json={"data_content": SAMPLE_CSV, "file_format": "csv", "sample_rows": 2},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["shape"]["rows"] == 3
+    assert data["shape"]["columns"] == 3
+    assert len(data["sample_data"]) == 2
+
+
+def test_data_info_bad_json_returns_400(client):
+    """POST /data-info with non-JSON body returns HTTP 400."""
+    response = client.post(
+        "/data-info",
+        content=b"not-json",
+        headers={"Content-Type": "application/json"},
+    )
+    assert response.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# /a2a/{agent_id}
+# ---------------------------------------------------------------------------
+
+from a2a_runtime import encode_message, decode_message  # noqa: E402
+
+
+def test_a2a_endpoint_unknown_agent(client):
+    """POST /a2a/no-such-agent returns HTTP 404."""
+    msg = encode_message({}, correlation_id="c", cycle=1, agent_id="no-such-agent")
+    response = client.post("/a2a/no-such-agent", json=msg)
+    assert response.status_code == 404
+
+
+def test_a2a_endpoint_bad_json_returns_400(client):
+    """POST /a2a/data-analyzer with non-JSON body returns HTTP 400."""
+    response = client.post(
+        "/a2a/data-analyzer",
+        content=b"not-json",
+        headers={"Content-Type": "application/json"},
+    )
+    assert response.status_code == 400
+
+
+def test_a2a_endpoint_unknown_operation(client):
+    """POST /a2a/data-analyzer with unknown operation returns HTTP 200 error dict."""
+    msg = encode_message(
+        {"operation": "fly-to-moon"},
+        correlation_id="corr-a2a-01",
+        cycle=1,
+        agent_id="data-analyzer",
+    )
+    response = client.post("/a2a/data-analyzer", json=msg)
+    assert response.status_code == 200
+    envelope = response.json()
+    # The response is itself an A2A message; decode it.
+    payload, meta = decode_message(envelope)
+    assert "error" in payload
+    assert payload.get("type") == "unknown_operation"
+
+
+def test_a2a_endpoint_correlation_id_preserved(client):
+    """POST /a2a/data-analyzer echoes back the correlation_id in the response envelope."""
+    msg = encode_message(
+        {"operation": "fly-to-moon"},
+        correlation_id="my-unique-id-xyz",
+        cycle=2,
+        agent_id="data-analyzer",
+    )
+    response = client.post("/a2a/data-analyzer", json=msg)
+    assert response.status_code == 200
+    envelope = response.json()
+    _, meta = decode_message(envelope)
+    assert meta["correlation_id"] == "my-unique-id-xyz"


### PR DESCRIPTION
## Summary
Makes the data-analyzer callable by other org systems through **three interfaces over one shared core**: REST API, MCP, and A2A — matching how `dcri-ct-graph` consumes agents (point a node's `a2a_endpoint` at `/a2a/data-analyzer`). Agent id: **`data-analyzer`**.

## What's done
- **Shared core** — `analysis_service.py` (`analyze` / `get_info`); MCP handlers, REST, and A2A all delegate here (no duplicated logic).
- **REST** — `api_server.py`: `/analyze`, `/data-info`, `/health`, plus the A2A `POST /a2a/{agent_id}` and AgentCard at `/.well-known/agent.json`. Binds Cloud Run's `$PORT`.
- **MCP** — existing `mcp_server.py` tools (`analyze_data`, `get_data_info`) refactored to call the shared service; schemas/output unchanged.
- **A2A** — `a2a_agent.py` (`DataAnalyzerAgent` + AgentCard); `a2a_runtime/` import-or-shim layer (prefers real `dcri-a2a-core`, falls back to a pure-stdlib shim mirroring its public API).
- **Real over-the-wire client** — `a2a_runtime/http_client.py` (stdlib `urllib`): the outbound HTTP hop `dcri-a2a-core` leaves as a stub. Socket-tested (round trip, bearer propagation, HTTP-error surfacing).
- **Cloud Run deploy** — `Dockerfile.api`, `requirements-api.txt`, `cloudbuild.yaml`, `deploy/cloudrun.sh`, `.github/workflows/deploy-cloudrun.yml` (`--allow-unauthenticated`).
- **Live proof** — `scripts/e2e_a2a_check.py` hits the deployed URL (`/health`, AgentCard, real `/a2a` analyze round trip).
- **Docs** — `docs/INTEGRATION.md` + README section; git-native handoff protocol added to `CLAUDE.md`.
- **Tests** — stdlib-only `tests/test_a2a_runtime.py` (runs offline) + pandas/fastapi-gated suites (`importorskip`) for CI.

## How to run / deploy
```bash
# Local API
pip install -r requirements-api.txt && python api_server.py   # API_PORT default 8003

# Deploy to Cloud Run (needs your gcloud login)
PROJECT_ID=<gcp-project> ./deploy/cloudrun.sh
python3 scripts/e2e_a2a_check.py --url <printed-run-url>
```
GitHub Actions deploy needs a **`GCP_SA_KEY`** secret (roles documented in the workflow header).

## Pending / caveats (not blockers)
- **a2a-sdk JSON-RPC parity**: `/a2a` speaks the canonical DCRI JSON envelope; verify/adjust the inbound parser against the real `a2a-sdk`-based `dcri-a2a-core` `message/send` framing when adopted.
- **Auth**: `--allow-unauthenticated` is demo-only — add a bearer-token guard before exposing real data.
- **Offline sandbox**: only the stdlib A2A layer was executed here; heavy tests run in CI.

## Required env vars
- `PORT` (Cloud Run-injected) / `API_PORT` (local); optional `dcri-a2a-core` install to bypass the shim.

https://claude.ai/code/session_01RG8v6PwLWzbazWZQ85pjzB

---
_Generated by [Claude Code](https://claude.ai/code/session_01RG8v6PwLWzbazWZQ85pjzB)_