### PR TITLE
Default deploy target → Azure Container Apps (Google Cloud Run kept as optional)

### DIFF
--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -1,0 +1,217 @@
+# .github/workflows/deploy-azure.yml
+#
+# DEFAULT GitHub Actions workflow — builds and deploys the data-analyzer API
+# to Azure Container Apps (the primary/default deployment target for this project).
+#
+# The Google Cloud Run workflow (.github/workflows/deploy-cloudrun.yml) is
+# OPTIONAL / non-default and exists only for an alternative public demo.
+#
+# ============================================================
+# REQUIRED GITHUB SECRET
+# ============================================================
+# AZURE_CREDENTIALS
+#   Service-principal JSON credential produced by:
+#
+#     az ad sp create-for-rbac \
+#       --name "gh-deploy-data-analyzer" \
+#       --role Contributor \
+#       --scopes /subscriptions/<SUBSCRIPTION_ID>/resourceGroups/<RESOURCE_GROUP> \
+#       --sdk-auth
+#
+#   Store the full JSON output as the AZURE_CREDENTIALS repository secret.
+#
+# SECURITY NOTE — OIDC Federated Credentials (recommended for production)
+#   The more secure alternative to a long-lived service-principal JSON key is
+#   OpenID Connect (OIDC) Workload Identity Federation. With OIDC, GitHub's
+#   short-lived token is exchanged for an Azure access token — no stored secret.
+#   To adopt it:
+#     1. Create an App Registration and Federated Credential in Entra ID.
+#     2. Replace the azure/login@v2 `creds:` input with:
+#          client-id: ${{ vars.AZURE_CLIENT_ID }}
+#          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+#          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+#     3. Add `id-token: write` permission to the job (already present below).
+#   See: https://learn.microsoft.com/en-us/azure/developer/github/connect-from-azure-openid-connect
+#
+# ============================================================
+
+name: Deploy to Azure Container Apps (DEFAULT)
+
+on:
+  workflow_dispatch:
+    inputs:
+      resource_group:
+        description: 'Azure resource group name'
+        required: false
+        default: 'rg-data-analyzer'
+        type: string
+      location:
+        description: 'Azure region'
+        required: false
+        default: 'eastus'
+        type: string
+      acr_name:
+        description: 'Azure Container Registry name (globally unique, 5-50 alphanumeric chars)'
+        required: true
+        type: string
+      app_name:
+        description: 'Container App name'
+        required: false
+        default: 'data-analyzer-api'
+        type: string
+
+jobs:
+  deploy:
+    name: Build and Deploy to Azure Container Apps
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write   # Required for OIDC federated credential auth (see header)
+
+    steps:
+      # ------------------------------------------------------------------
+      # 1. Checkout source
+      # ------------------------------------------------------------------
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # ------------------------------------------------------------------
+      # 2. Authenticate to Azure using the service-principal JSON secret.
+      #    To switch to OIDC (recommended), replace `creds:` with
+      #    client-id / tenant-id / subscription-id (see header comment).
+      # ------------------------------------------------------------------
+      - name: Authenticate to Azure
+        uses: azure/login@v2
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      # ------------------------------------------------------------------
+      # 3. Ensure the resource group exists (idempotent)
+      # ------------------------------------------------------------------
+      - name: Ensure resource group
+        run: |
+          az group create \
+            --name "${{ inputs.resource_group }}" \
+            --location "${{ inputs.location }}" \
+            --output none
+
+      # ------------------------------------------------------------------
+      # 4. Ensure ACR exists and enable admin credentials
+      # ------------------------------------------------------------------
+      - name: Ensure Azure Container Registry
+        run: |
+          az acr create \
+            --name "${{ inputs.acr_name }}" \
+            --resource-group "${{ inputs.resource_group }}" \
+            --sku Basic \
+            --output none \
+            2>&1 || true
+
+          az acr update \
+            --name "${{ inputs.acr_name }}" \
+            --admin-enabled true \
+            --output none
+
+      # ------------------------------------------------------------------
+      # 5. Build and push image via ACR Tasks (no local Docker required)
+      # ------------------------------------------------------------------
+      - name: Build image via az acr build
+        run: |
+          az acr build \
+            --registry "${{ inputs.acr_name }}" \
+            --image "${{ inputs.app_name }}:${{ github.sha }}" \
+            --file Dockerfile.api \
+            .
+
+      # ------------------------------------------------------------------
+      # 6. Ensure Container Apps extension and environment exist
+      # ------------------------------------------------------------------
+      - name: Ensure Container Apps extension and environment
+        run: |
+          az extension add --name containerapp --upgrade --output none 2>&1 || true
+
+          az containerapp env create \
+            --name "aca-env-data-analyzer" \
+            --resource-group "${{ inputs.resource_group }}" \
+            --location "${{ inputs.location }}" \
+            --output none \
+            2>&1 || true
+
+      # ------------------------------------------------------------------
+      # 7. Derive ACR login server and credentials, then create or update
+      #    the Container App with external ingress on port 8080
+      # ------------------------------------------------------------------
+      - name: Create or update Container App
+        id: deploy-app
+        run: |
+          LOGIN_SERVER=$(az acr show \
+            --name "${{ inputs.acr_name }}" \
+            --query loginServer --output tsv)
+          ACR_USERNAME=$(az acr credential show \
+            --name "${{ inputs.acr_name }}" \
+            --query username --output tsv)
+          ACR_PASSWORD=$(az acr credential show \
+            --name "${{ inputs.acr_name }}" \
+            --query 'passwords[0].value' --output tsv)
+
+          IMAGE="${LOGIN_SERVER}/${{ inputs.app_name }}:${{ github.sha }}"
+
+          # Attempt create; fall back to update if the app already exists.
+          if ! az containerapp create \
+              --name "${{ inputs.app_name }}" \
+              --resource-group "${{ inputs.resource_group }}" \
+              --environment "aca-env-data-analyzer" \
+              --image "${IMAGE}" \
+              --target-port 8080 \
+              --ingress external \
+              --registry-server "${LOGIN_SERVER}" \
+              --registry-username "${ACR_USERNAME}" \
+              --registry-password "${ACR_PASSWORD}" \
+              --output none \
+              2>/dev/null; then
+            az containerapp update \
+              --name "${{ inputs.app_name }}" \
+              --resource-group "${{ inputs.resource_group }}" \
+              --image "${IMAGE}" \
+              --output none
+          fi
+
+          FQDN=$(az containerapp show \
+            --name "${{ inputs.app_name }}" \
+            --resource-group "${{ inputs.resource_group }}" \
+            --query properties.configuration.ingress.fqdn \
+            --output tsv)
+
+          echo "fqdn=${FQDN}" >> "$GITHUB_OUTPUT"
+          echo "public_url=https://${FQDN}" >> "$GITHUB_OUTPUT"
+
+      # ------------------------------------------------------------------
+      # 8. Write URL and verification commands to job summary
+      # ------------------------------------------------------------------
+      - name: Write summary
+        run: |
+          {
+            echo "## Azure Container Apps Deployment (DEFAULT)"
+            echo ""
+            echo "| Field | Value |"
+            echo "|-------|-------|"
+            echo "| App | \`${{ inputs.app_name }}\` |"
+            echo "| Resource Group | \`${{ inputs.resource_group }}\` |"
+            echo "| Location | \`${{ inputs.location }}\` |"
+            echo "| ACR | \`${{ inputs.acr_name }}\` |"
+            echo "| Commit | \`${{ github.sha }}\` |"
+            echo "| **Public URL** | ${{ steps.deploy-app.outputs.public_url }} |"
+            echo ""
+            echo "### Quick smoke test"
+            echo "\`\`\`bash"
+            echo "curl ${{ steps.deploy-app.outputs.public_url }}/health"
+            echo "\`\`\`"
+            echo ""
+            echo "### End-to-end A2A check"
+            echo "\`\`\`bash"
+            echo "python3 scripts/e2e_a2a_check.py --url ${{ steps.deploy-app.outputs.public_url }}"
+            echo "\`\`\`"
+            echo ""
+            echo "> **Security reminder:** External ingress is public/unauthenticated."
+            echo "> Add Entra ID authentication or Azure API Management before processing real data."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy-cloudrun.yml
+++ b/.github/workflows/deploy-cloudrun.yml
@@ -1,3 +1,11 @@
+# ============================================================
+# OPTIONAL / NON-DEFAULT — Google Cloud Run path.
+# The DEFAULT deploy target for this project is AZURE
+# (Azure Container Apps): see deploy/azure-containerapp.sh and
+# .github/workflows/deploy-azure.yml. These GCP files exist only
+# for an optional public demo; do not use unless you are
+# explicitly deploying to Google Cloud.
+# ============================================================
 # .github/workflows/deploy-cloudrun.yml
 #
 # Manual GitHub Actions workflow to build and deploy the data-analyzer API
@@ -42,7 +50,7 @@
 #   - Google Cloud Endpoints / API Gateway with an API key or JWT
 # ============================================================
 
-name: Deploy to Cloud Run
+name: "[OPTIONAL / non-default — Google Cloud Run] Deploy to Cloud Run"
 
 on:
   workflow_dispatch:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,3 +1,11 @@
+# ============================================================
+# OPTIONAL / NON-DEFAULT — Google Cloud Run path.
+# The DEFAULT deploy target for this project is AZURE
+# (Azure Container Apps): see deploy/azure-containerapp.sh and
+# .github/workflows/deploy-azure.yml. These GCP files exist only
+# for an optional public demo; do not use unless you are
+# explicitly deploying to Google Cloud.
+# ============================================================
 # cloudbuild.yaml — Google Cloud Build configuration for the API image.
 #
 # Usage (via deploy/cloudrun.sh or manually):

--- a/deploy/azure-containerapp.sh
+++ b/deploy/azure-containerapp.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+# deploy/azure-containerapp.sh — DEFAULT deploy target for the data-analyzer project.
+#
+# This script deploys the data-analyzer API to Azure Container Apps, which is the
+# primary and default deployment target for this project.
+# For the optional Google Cloud Run path, see deploy/cloudrun.sh.
+#
+# USAGE
+#   ACR_NAME=myregistry123 ./deploy/azure-containerapp.sh
+#
+# REQUIRED ENVIRONMENT VARIABLES
+#   ACR_NAME   Azure Container Registry name (REQUIRED — no default).
+#              Must be globally unique across all of Azure.
+#              Constraints: 5-50 characters, alphanumeric only (no hyphens or underscores).
+#              Example: ACR_NAME=dataanalyzer42acr
+#
+# OPTIONAL ENVIRONMENT VARIABLES (with sensible defaults)
+#   RESOURCE_GROUP   Azure resource group name    (default: rg-data-analyzer)
+#   LOCATION         Azure region                 (default: eastus)
+#   ACA_ENV          Container Apps environment   (default: aca-env-data-analyzer)
+#   APP_NAME         Container App name           (default: data-analyzer-api)
+#   IMAGE_TAG        Image tag to build/deploy    (default: latest)
+#
+# PREREQUISITES
+#   - Azure CLI authenticated:  az login
+#   - Sufficient permissions on the subscription/resource group:
+#       Contributor or Owner on the resource group (for resource creation)
+#       AcrPush on the ACR (for image push via acr build)
+#
+# WHAT THIS SCRIPT DOES
+#   1. Creates the resource group (idempotent).
+#   2. Creates the Azure Container Registry with Basic SKU (idempotent).
+#   3. Enables ACR admin credentials (used for Container Apps pull authentication).
+#   4. Builds the image in the cloud via `az acr build` (no local Docker required).
+#   5. Ensures the Container Apps extension and environment exist (idempotent).
+#   6. Creates or updates the Container App with external ingress on port 8080.
+#   7. Prints the public HTTPS URL and reminds you to run the e2e check.
+#
+# AUTHENTICATION NOTE — ACR admin credentials
+#   This script uses ACR admin credentials (username/password) for the Container App
+#   to pull images. Admin credentials are simple and sufficient for demos and small teams.
+#   For production or team environments consider using a managed identity instead:
+#     az containerapp create ... --registry-identity system
+#   and grant the app's system identity AcrPull on the ACR.
+#
+# SECURITY NOTE
+#   External ingress is public/unauthenticated — anyone on the internet can call
+#   /analyze, /data-info, and /a2a/data-analyzer. This is acceptable for demos and
+#   proofs-of-concept. Before processing real or sensitive data, add authentication:
+#     - Azure API Management in front with key/JWT enforcement
+#     - Microsoft Entra ID (formerly Azure AD) authentication on the Container App
+#       (az containerapp auth update --enabled true)
+#     - VNet integration with private ingress only
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+: "${ACR_NAME:?ERROR: ACR_NAME environment variable must be set. It must be globally unique, 5-50 alphanumeric characters (no hyphens). Example: ACR_NAME=dataanalyzer42acr}"
+
+RESOURCE_GROUP="${RESOURCE_GROUP:-rg-data-analyzer}"
+LOCATION="${LOCATION:-eastus}"
+ACA_ENV="${ACA_ENV:-aca-env-data-analyzer}"
+APP_NAME="${APP_NAME:-data-analyzer-api}"
+IMAGE_TAG="${IMAGE_TAG:-latest}"
+
+echo "================================================================"
+echo "  Deploying data-analyzer API to Azure Container Apps (DEFAULT)"
+echo "  Resource Group : ${RESOURCE_GROUP}"
+echo "  Location       : ${LOCATION}"
+echo "  ACR Name       : ${ACR_NAME}"
+echo "  ACA Environment: ${ACA_ENV}"
+echo "  App Name       : ${APP_NAME}"
+echo "  Image Tag      : ${IMAGE_TAG}"
+echo "================================================================"
+
+# ---------------------------------------------------------------------------
+# Step 1: Ensure the resource group exists
+# ---------------------------------------------------------------------------
+echo ""
+echo "[1/6] Ensuring resource group '${RESOURCE_GROUP}' exists..."
+az group create \
+    --name "${RESOURCE_GROUP}" \
+    --location "${LOCATION}" \
+    --output none
+echo "  Resource group ready."
+
+# ---------------------------------------------------------------------------
+# Step 2: Ensure the Azure Container Registry exists
+# ---------------------------------------------------------------------------
+echo ""
+echo "[2/6] Ensuring Azure Container Registry '${ACR_NAME}' exists..."
+az acr create \
+    --name "${ACR_NAME}" \
+    --resource-group "${RESOURCE_GROUP}" \
+    --sku Basic \
+    --output none \
+    2>&1 || true   # 'already exists' is not an error
+
+# Enable admin credentials so the Container App can authenticate to pull images.
+# (See AUTHENTICATION NOTE in the header for a managed-identity alternative.)
+echo "  Enabling ACR admin credentials..."
+az acr update \
+    --name "${ACR_NAME}" \
+    --admin-enabled true \
+    --output none
+echo "  ACR ready."
+
+# ---------------------------------------------------------------------------
+# Step 3: Build the image in the cloud via ACR Tasks (no local Docker needed)
+# ---------------------------------------------------------------------------
+echo ""
+echo "[3/6] Building image '${APP_NAME}:${IMAGE_TAG}' via az acr build..."
+# Run from the repo root (parent of this script's directory).
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+az acr build \
+    --registry "${ACR_NAME}" \
+    --image "${APP_NAME}:${IMAGE_TAG}" \
+    --file "${REPO_ROOT}/Dockerfile.api" \
+    "${REPO_ROOT}"
+echo "  Image build and push complete."
+
+# ---------------------------------------------------------------------------
+# Step 4: Ensure the Container Apps extension and environment exist
+# ---------------------------------------------------------------------------
+echo ""
+echo "[4/6] Ensuring Container Apps extension and environment exist..."
+az extension add --name containerapp --upgrade --output none 2>&1 || true
+
+az containerapp env create \
+    --name "${ACA_ENV}" \
+    --resource-group "${RESOURCE_GROUP}" \
+    --location "${LOCATION}" \
+    --output none \
+    2>&1 || true   # 'already exists' is not an error
+echo "  Container Apps environment ready."
+
+# ---------------------------------------------------------------------------
+# Step 5: Derive ACR login server and credentials
+# ---------------------------------------------------------------------------
+echo ""
+echo "[5/6] Retrieving ACR credentials..."
+LOGIN_SERVER="$(az acr show --name "${ACR_NAME}" --query loginServer --output tsv)"
+ACR_USERNAME="$(az acr credential show --name "${ACR_NAME}" --query username --output tsv)"
+ACR_PASSWORD="$(az acr credential show --name "${ACR_NAME}" --query 'passwords[0].value' --output tsv)"
+echo "  ACR login server: ${LOGIN_SERVER}"
+
+# ---------------------------------------------------------------------------
+# Step 6: Create or update the Container App
+# ---------------------------------------------------------------------------
+echo ""
+echo "[6/6] Creating or updating Container App '${APP_NAME}'..."
+
+# Attempt to create the app. If it already exists, fall back to update.
+if az containerapp create \
+    --name "${APP_NAME}" \
+    --resource-group "${RESOURCE_GROUP}" \
+    --environment "${ACA_ENV}" \
+    --image "${LOGIN_SERVER}/${APP_NAME}:${IMAGE_TAG}" \
+    --target-port 8080 \
+    --ingress external \
+    --registry-server "${LOGIN_SERVER}" \
+    --registry-username "${ACR_USERNAME}" \
+    --registry-password "${ACR_PASSWORD}" \
+    --query properties.configuration.ingress.fqdn \
+    --output tsv \
+    2>/dev/null; then
+    echo "  Container App created."
+else
+    echo "  Container App already exists — updating image..."
+    az containerapp update \
+        --name "${APP_NAME}" \
+        --resource-group "${RESOURCE_GROUP}" \
+        --image "${LOGIN_SERVER}/${APP_NAME}:${IMAGE_TAG}" \
+        --output none
+    echo "  Container App updated."
+fi
+
+# ---------------------------------------------------------------------------
+# Print the public URL
+# ---------------------------------------------------------------------------
+echo ""
+FQDN="$(az containerapp show \
+    --name "${APP_NAME}" \
+    --resource-group "${RESOURCE_GROUP}" \
+    --query properties.configuration.ingress.fqdn \
+    --output tsv)"
+
+PUBLIC_URL="https://${FQDN}"
+
+echo "================================================================"
+echo "  Deployment complete!"
+echo "  Public URL : ${PUBLIC_URL}"
+echo ""
+echo "  Verify with:"
+echo "    curl ${PUBLIC_URL}/health"
+echo ""
+echo "  Run the end-to-end check:"
+echo "    python3 scripts/e2e_a2a_check.py --url ${PUBLIC_URL}"
+echo ""
+echo "  SECURITY REMINDER: External ingress is currently public/"
+echo "  unauthenticated. Add Entra ID authentication or an API"
+echo "  gateway before exposing real/sensitive data."
+echo "================================================================"

--- a/deploy/cloudrun.sh
+++ b/deploy/cloudrun.sh
@@ -1,4 +1,12 @@
 #!/usr/bin/env bash
+# ============================================================
+# OPTIONAL / NON-DEFAULT — Google Cloud Run path.
+# The DEFAULT deploy target for this project is AZURE
+# (Azure Container Apps): see deploy/azure-containerapp.sh and
+# .github/workflows/deploy-azure.yml. These GCP files exist only
+# for an optional public demo; do not use unless you are
+# explicitly deploying to Google Cloud.
+# ============================================================
 # deploy/cloudrun.sh — Manual deploy script for the data-analyzer API on Cloud Run.
 #
 # USAGE

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -1,5 +1,7 @@
 # Integration Guide — Calling the Data Analyzer Service
 
+**Default deploy target: Azure Container Apps. Google Cloud Run is an optional alternative.**
+
 The Data Analyzer exposes the **same core analysis logic** through three independent interfaces. Choose the interface that fits your client:
 
 | Interface | When to use |
@@ -255,9 +257,101 @@ The API server does not implement authentication itself — that is a **deployme
 
 ---
 
-## Deploying to Google Cloud Run (public, unauthenticated)
+## Deploying (default: Azure Container Apps)
 
-The repository ships with a ready-to-use Cloud Run deployment path that builds a minimal API image (no Streamlit, no LLM packages) and deploys it as a fully public HTTPS endpoint.
+Azure Container Apps is the **primary and default deployment target** for this project. The same `Dockerfile.api` is used (listens on `${PORT:-8080}`).
+
+### One-command deploy
+
+```bash
+ACR_NAME=myregistry123 ./deploy/azure-containerapp.sh
+```
+
+`ACR_NAME` is the only required variable — it must be globally unique across Azure (5-50 alphanumeric characters, no hyphens). All other variables have sensible defaults:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ACR_NAME` | **(required)** | Azure Container Registry name — globally unique, 5-50 alphanumeric chars |
+| `RESOURCE_GROUP` | `rg-data-analyzer` | Azure resource group |
+| `LOCATION` | `eastus` | Azure region |
+| `ACA_ENV` | `aca-env-data-analyzer` | Container Apps environment name |
+| `APP_NAME` | `data-analyzer-api` | Container App name |
+| `IMAGE_TAG` | `latest` | Image tag |
+
+The script will (all steps are idempotent — safe to re-run):
+1. Create the resource group.
+2. Create the ACR with Basic SKU and enable admin credentials.
+3. Build `Dockerfile.api` in the cloud via `az acr build` (no local Docker required).
+4. Ensure the Container Apps extension and environment exist.
+5. Create or update the Container App with external HTTPS ingress on port 8080.
+6. Print the resulting public HTTPS URL.
+
+### GitHub Actions alternative
+
+A `workflow_dispatch` workflow is provided at `.github/workflows/deploy-azure.yml`. Trigger it from the GitHub Actions UI (Actions tab → "Deploy to Azure Container Apps (DEFAULT)" → Run workflow) and supply:
+- **acr_name** (required — globally unique registry name)
+- **resource_group** (default `rg-data-analyzer`)
+- **location** (default `eastus`)
+- **app_name** (default `data-analyzer-api`)
+
+The public FQDN URL is echoed into the job summary after a successful deploy.
+
+**Required GitHub secret — `AZURE_CREDENTIALS`:**
+Create a service principal and store its JSON output as the `AZURE_CREDENTIALS` repository secret:
+
+```bash
+az ad sp create-for-rbac \
+  --name "gh-deploy-data-analyzer" \
+  --role Contributor \
+  --scopes /subscriptions/<SUBSCRIPTION_ID>/resourceGroups/rg-data-analyzer \
+  --sdk-auth
+```
+
+**OIDC Workload Identity Federation is the more secure alternative.** OIDC eliminates long-lived service-principal JSON keys by federating GitHub's short-lived token directly into Azure. See [azure/login — OIDC](https://learn.microsoft.com/en-us/azure/developer/github/connect-from-azure-openid-connect). Replace `creds: ${{ secrets.AZURE_CREDENTIALS }}` with `client-id`, `tenant-id`, and `subscription-id` variables to adopt it.
+
+### Getting the FQDN after deploy
+
+```bash
+az containerapp show \
+    --name data-analyzer-api \
+    --resource-group rg-data-analyzer \
+    --query properties.configuration.ingress.fqdn \
+    --output tsv
+```
+
+The public URL is `https://<fqdn>`.
+
+### End-to-end check
+
+After deploy, run the live proof script against the public URL:
+
+```bash
+python3 scripts/e2e_a2a_check.py --url https://<fqdn>
+```
+
+The script (stdlib-only, no pip installs) verifies:
+1. `GET /health` returns `status: ok` with `a2a_backend` present.
+2. `GET /.well-known/agent.json` card `url` equals `/a2a/data-analyzer`.
+3. A base64-encoded CSV is sent via `call_agent_http()` and the response contains quality-pipeline keys (`checks`, `summary_stats`, etc.).
+
+It prints a concise PASS/FAIL summary and exits non-zero on any failure.
+
+### Security WARNING
+
+External ingress makes the `/analyze`, `/data-info`, and `/a2a/data-analyzer` endpoints reachable by **anyone on the public internet**. This is acceptable for a temporary demo or internal proof-of-concept. Before processing real patient data or any sensitive information:
+
+- Enable Microsoft Entra ID (formerly Azure AD) authentication on the Container App:
+  `az containerapp auth update --name data-analyzer-api --resource-group rg-data-analyzer --enabled true`
+- Place Azure API Management in front with key/JWT enforcement.
+- Switch to private ingress with VNet integration for network-level isolation.
+
+---
+
+## Deploying (optional / non-default: Google Cloud Run)
+
+> **Not the default** — the default deployment target is Azure Container Apps (above).
+
+The repository also ships with a Google Cloud Run deployment path that builds the same minimal API image and deploys it as a fully public HTTPS endpoint. Use this only if you are explicitly targeting Google Cloud.
 
 ### One-command deploy
 


### PR DESCRIPTION
## Summary
Switches the **default deploy target to Azure Container Apps** (the org runs on Azure). The Google Cloud Run files from the prior PR are **kept but clearly annotated as optional / non-default**, so any future session sees Azure is the default.

## What's in this PR
- **`deploy/azure-containerapp.sh`** (default) — `az acr build` + `az containerapp create/update`, external ingress on port 8080, same `Dockerfile.api`. Idempotent; prints the public FQDN and the e2e check command.
- **`.github/workflows/deploy-azure.yml`** — `workflow_dispatch` deploy via `azure/login` (`AZURE_CREDENTIALS` secret); URL written to the job summary.
- **Google files annotated** — `cloudbuild.yaml`, `deploy/cloudrun.sh`, `.github/workflows/deploy-cloudrun.yml` get an "OPTIONAL / NON-DEFAULT — default is Azure" banner; the Cloud Run workflow is renamed accordingly. No GCP logic changed.
- **`docs/INTEGRATION.md`** — Azure-first; bold default-target line; Cloud Run section retitled "optional / non-default".

## Deploy (on a machine with Azure CLI)
```bash
az login
ACR_NAME=<globally-unique-registry-name> ./deploy/azure-containerapp.sh   # prints FQDN
python3 scripts/e2e_a2a_check.py --url https://<printed-fqdn>             # exit 0 = live
```
GitHub Actions path: add an `AZURE_CREDENTIALS` secret (`az ad sp create-for-rbac --sdk-auth`), run the "Deploy to Azure Container Apps (DEFAULT)" workflow.

## Notes
- External ingress is public/unauthenticated (demo) — add Entra/bearer auth before real data.
- a2a-sdk JSON-RPC parity and a security pass remain optional follow-ups.

https://claude.ai/code/session_01RG8v6PwLWzbazWZQ85pjzB

---
_Generated by [Claude Code](https://claude.ai/code/session_01RG8v6PwLWzbazWZQ85pjzB)_